### PR TITLE
fix: ensure all packages are released together.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish package to PyPI
 on:
   push:
     tags:
-      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "microsoft-kiota-abstractionsv*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 permissions:
   contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,8 @@ name: Publish package to PyPI
 on:
   push:
     tags:
-      - "microsoft-kiota-abstractionsv*" # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "microsoft-kiota-abstractions-v*" # Push events to matching microsoft-kiota-abstractions-v*, i.e. microsoft-kiota-abstractions-v1.0, microsoft-kiota-abstractions-v20.15.10
+                                          # All packages are ideally released together so we can use the same tag for all packages
 
 permissions:
   contents: write

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "exclude-paths": [".git", ".idea", ".github", ".vscode"],
-  "include-component-in-tag": false,
+  "include-component-in-tag": true,
   "include-v-in-tag": true,
   "separate-pull-requests": false,
   "bump-minor-pre-major": true,


### PR DESCRIPTION
Looks like according to https://github.com/googleapis/release-please/pull/1749 for the `linked-versions` plugin to align the versions, the component will need to be included in the tag. 

This will change the tag format in the repo from `v1.2.0` to be `microsoft-kiota-abstractions-v1.2.0` (therefore publishing a tag for each library similar to [kiota-typescript](https://github.com/microsoft/kiota-typescript/tags))