### PR TITLE
correctly serialize None in a list

### DIFF
--- a/packages/serialization/json/kiota_serialization_json/json_serialization_writer.py
+++ b/packages/serialization/json/kiota_serialization_json/json_serialization_writer.py
@@ -14,6 +14,7 @@ T = TypeVar("T")
 U = TypeVar("U", bound=Parsable)
 K = TypeVar("K", bound=Enum)
 PRIMITIVE_TYPES = [bool, str, int, float, UUID, datetime, timedelta, date, time, bytes, Enum]
+PRIMITIVE_TYPES_WITH_NONE = PRIMITIVE_TYPES + [type(None)]
 
 
 class JsonSerializationWriter(SerializationWriter):
@@ -341,7 +342,7 @@ class JsonSerializationWriter(SerializationWriter):
         if key:
             self.writer[key] = None
         else:
-            self.value = "null"
+            self.value = None
 
     def __write_dict_value(self, key: Optional[str], value: Dict[str, Any]) -> None:
         """Writes the specified dictionary value to the stream with an optional given key.
@@ -474,7 +475,7 @@ class JsonSerializationWriter(SerializationWriter):
             elif all(isinstance(x, Enum) for x in value):
                 self.write_collection_of_enum_values(key, value)
             elif all(
-                any(isinstance(x, primitive_type) for primitive_type in PRIMITIVE_TYPES)
+                any(isinstance(x, primitive_type) for primitive_type in PRIMITIVE_TYPES_WITH_NONE)
                 for x in value
             ):
                 self.write_collection_of_primitive_values(key, value)

--- a/packages/serialization/json/tests/unit/test_json_serialization_writer.py
+++ b/packages/serialization/json/tests/unit/test_json_serialization_writer.py
@@ -259,7 +259,8 @@ def test_write_additional_data_value(user_1, user_2):
                 "groups": [{
                     "friends": [user_2]
                 }]
-            }
+            },
+            "pinnedItems": [None, None]
         }
     )
     content = json_serialization_writer.get_serialized_content()
@@ -272,4 +273,5 @@ def test_write_additional_data_value(user_1, user_2):
             '"approvers": [{"id": "8f841f30-e6e3-439a-a812-ebd369559c36", '\
                 '"updated_at": "2022-01-27T12:59:45.596117+00:00", "is_active": true}, '\
                 '{"display_name": "John Doe", "age": 32}], "created_at": "2022-01-27", '\
-                '"data": {"groups": [{"friends": [{"display_name": "John Doe", "age": 32}]}]}}'
+                '"data": {"groups": [{"friends": [{"display_name": "John Doe", "age": 32}]}]}, '\
+                    '"pinnedItems": [null, null]}'


### PR DESCRIPTION
## Overview

We currently have two issues:
1. We don't support `None` inside lists.
2. We convert `None` to `'null'` when there is no key. Simply fixing issue 1 would result in `['null', 'null']` instead of `[null, null]`.

The first issue arises when fetching, for example, all graph site pages of a site and attempting to serialize them. A specific case involves expanding `canvasLayout` and receiving a page without a `canvasLayout`, which results in `pinnedItems` containing `[None, None, None]`.

Although whether this response is correct is another question, the serialization should not raise an exception in this scenario but should handle it appropriately.

## Testing Instructions

I have added relevant tests. Simply run `pytest` to verify the fix. Running the same tests without my changes will result in an exception.