### PR TITLE
fix: fixes typing issues discovered from github api generation

### DIFF
--- a/packages/abstractions/kiota_abstractions/request_adapter.py
+++ b/packages/abstractions/kiota_abstractions/request_adapter.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import date, datetime, time, timedelta
 from io import BytesIO
 from typing import Dict, Generic, List, Optional, TypeVar, Union
+from uuid import UUID
 
 from .request_information import RequestInformation
 from .serialization import Parsable, ParsableFactory, SerializationWriterFactory
@@ -11,7 +12,7 @@ from .store import BackingStoreFactory
 ResponseType = TypeVar("ResponseType")
 ModelType = TypeVar("ModelType", bound=Parsable)
 RequestType = TypeVar("RequestType")
-
+PrimitiveType = TypeVar("PrimitiveType", bool, str, int, float, UUID, datetime, timedelta, date, time, bytes)
 
 class RequestAdapter(ABC, Generic[RequestType]):
     """Service responsible for translating abstract Request Info into concrete native HTTP requests.
@@ -75,21 +76,21 @@ class RequestAdapter(ABC, Generic[RequestType]):
     async def send_collection_of_primitive_async(
         self,
         request_info: RequestInformation,
-        response_type: type[ResponseType],
+        response_type: type[PrimitiveType],
         error_map: Optional[Dict[str, type[ParsableFactory]]],
-    ) -> Optional[List[ResponseType]]:
+    ) -> Optional[List[PrimitiveType]]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
         deserialized response model collection.
 
         Args:
             request_info (RequestInformation): the request info to execute.
-            response_type (ResponseType): the class of the response model to deserialize the
+            response_type (PrimitiveType): the class of the response model to deserialize the
             response into.
             error_map (Optional[Dict[str, type[ParsableFactory]]]): the error dict to use in
             case of a failed request.
 
         Returns:
-            Optional[List[ModelType]]: The deserialized response model collection.
+            Optional[List[PrimitiveType]]: The deserialized primitive collection.
         """
         pass
 

--- a/packages/abstractions/kiota_abstractions/request_adapter.py
+++ b/packages/abstractions/kiota_abstractions/request_adapter.py
@@ -75,7 +75,7 @@ class RequestAdapter(ABC, Generic[RequestType]):
     async def send_collection_of_primitive_async(
         self,
         request_info: RequestInformation,
-        response_type: ResponseType,
+        response_type: type[ResponseType],
         error_map: Optional[Dict[str, type[ParsableFactory]]],
     ) -> Optional[List[ResponseType]]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the

--- a/packages/abstractions/kiota_abstractions/request_adapter.py
+++ b/packages/abstractions/kiota_abstractions/request_adapter.py
@@ -12,7 +12,10 @@ from .store import BackingStoreFactory
 ResponseType = TypeVar("ResponseType")
 ModelType = TypeVar("ModelType", bound=Parsable)
 RequestType = TypeVar("RequestType")
-PrimitiveType = TypeVar("PrimitiveType", bool, str, int, float, UUID, datetime, timedelta, date, time, bytes)
+PrimitiveType = TypeVar(
+    "PrimitiveType", bool, str, int, float, UUID, datetime, timedelta, date, time, bytes
+)
+
 
 class RequestAdapter(ABC, Generic[RequestType]):
     """Service responsible for translating abstract Request Info into concrete native HTTP requests.

--- a/packages/abstractions/kiota_abstractions/serialization/parse_node.py
+++ b/packages/abstractions/kiota_abstractions/serialization/parse_node.py
@@ -118,7 +118,7 @@ class ParseNode(ABC):
         pass
 
     @abstractmethod
-    def get_collection_of_primitive_values(self, primitive_type) -> Optional[List[T]]:
+    def get_collection_of_primitive_values(self, primitive_type: type[T]) -> Optional[List[T]]:
         """Gets the collection of primitive values of the node
         Args:
             primitive_type: The type of primitive to return.
@@ -128,7 +128,7 @@ class ParseNode(ABC):
         pass
 
     @abstractmethod
-    def get_collection_of_object_values(self, factory: ParsableFactory) -> Optional[List[U]]:
+    def get_collection_of_object_values(self, factory: ParsableFactory[U]) -> Optional[List[U]]:
         """Gets the collection of model object values of the node
         Args:
             factory (ParsableFactory): The factory to use to create the model object.

--- a/packages/http/httpx/kiota_http/httpx_request_adapter.py
+++ b/packages/http/httpx/kiota_http/httpx_request_adapter.py
@@ -250,7 +250,7 @@ class HttpxRequestAdapter(RequestAdapter):
     async def send_collection_of_primitive_async(
         self,
         request_info: RequestInformation,
-        response_type: ResponseType,
+        response_type: type[ResponseType],
         error_map: Optional[Dict[str, type[ParsableFactory]]],
     ) -> Optional[List[ResponseType]]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the

--- a/packages/http/httpx/kiota_http/httpx_request_adapter.py
+++ b/packages/http/httpx/kiota_http/httpx_request_adapter.py
@@ -11,7 +11,7 @@ from kiota_abstractions.api_client_builder import (
 )
 from kiota_abstractions.api_error import APIError
 from kiota_abstractions.authentication import AuthenticationProvider
-from kiota_abstractions.request_adapter import RequestAdapter, ResponseType,PrimitiveType
+from kiota_abstractions.request_adapter import RequestAdapter, ResponseType, PrimitiveType
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.serialization import (
     Parsable,

--- a/packages/http/httpx/kiota_http/httpx_request_adapter.py
+++ b/packages/http/httpx/kiota_http/httpx_request_adapter.py
@@ -11,7 +11,7 @@ from kiota_abstractions.api_client_builder import (
 )
 from kiota_abstractions.api_error import APIError
 from kiota_abstractions.authentication import AuthenticationProvider
-from kiota_abstractions.request_adapter import RequestAdapter, ResponseType
+from kiota_abstractions.request_adapter import RequestAdapter, ResponseType,PrimitiveType
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.serialization import (
     Parsable,
@@ -250,20 +250,20 @@ class HttpxRequestAdapter(RequestAdapter):
     async def send_collection_of_primitive_async(
         self,
         request_info: RequestInformation,
-        response_type: type[ResponseType],
+        response_type: type[PrimitiveType],
         error_map: Optional[Dict[str, type[ParsableFactory]]],
-    ) -> Optional[List[ResponseType]]:
+    ) -> Optional[List[PrimitiveType]]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
         deserialized response model collection.
         Args:
             request_info (RequestInformation): the request info to execute.
-            response_type (ResponseType): the class of the response model
+            response_type (PrimitiveType): the class of the response model
             to deserialize the response into.
             error_map (Dict[str, type[ParsableFactory]]): the error dict to use in
             case of a failed request.
 
         Returns:
-            Optional[List[ResponseType]]: he deserialized response model collection.
+            Optional[List[PrimitiveType]]: The deserialized primitive type collection.
         """
         parent_span = self.start_tracing_span(request_info, "send_collection_of_primitive_async")
         try:

--- a/packages/serialization/form/kiota_serialization_form/form_parse_node.py
+++ b/packages/serialization/form/kiota_serialization_form/form_parse_node.py
@@ -167,7 +167,7 @@ class FormParseNode(ParseNode):
             return FormParseNode(self._fields[field_name])
         return None
 
-    def get_collection_of_primitive_values(self, primitive_type: type) -> Optional[List[T]]:
+    def get_collection_of_primitive_values(self, primitive_type: type[T]) -> Optional[List[T]]:
         """Gets the collection of primitive values of the node
         Args:
             primitive_type: The type of primitive to return.
@@ -189,7 +189,7 @@ class FormParseNode(ParseNode):
             return result
         raise Exception(f"Encountered an unknown type during deserialization {primitive_type}")
 
-    def get_collection_of_object_values(self, factory: ParsableFactory) -> Optional[List[U]]:
+    def get_collection_of_object_values(self, factory: ParsableFactory[U]) -> Optional[List[U]]:
         raise Exception("Collection of object values is not supported with uri form encoding.")
 
     def get_collection_of_enum_values(self, enum_class: K) -> Optional[List[K]]:

--- a/packages/serialization/json/kiota_serialization_json/json_parse_node.py
+++ b/packages/serialization/json/kiota_serialization_json/json_parse_node.py
@@ -139,7 +139,7 @@ class JsonParseNode(ParseNode):
                 return datetime_obj
         return None
 
-    def get_collection_of_primitive_values(self, primitive_type: Any) -> Optional[List[T]]:
+    def get_collection_of_primitive_values(self, primitive_type: type[T]) -> Optional[List[T]]:
         """Gets the collection of primitive values of the node
         Args:
             primitive_type: The type of primitive to return.
@@ -161,7 +161,7 @@ class JsonParseNode(ParseNode):
             return list(map(func, json.loads(self._json_node)))
         return list(map(func, list(self._json_node)))
 
-    def get_collection_of_object_values(self, factory: ParsableFactory) -> Optional[List[U]]:
+    def get_collection_of_object_values(self, factory: ParsableFactory[U]) -> Optional[List[U]]:
         """Gets the collection of type U values from the json node
         Returns:
             List[U]: The collection of model object values of the node

--- a/packages/serialization/text/kiota_serialization_text/text_parse_node.py
+++ b/packages/serialization/text/kiota_serialization_text/text_parse_node.py
@@ -133,7 +133,7 @@ class TextParseNode(ParseNode):
             return datetime_obj.time()
         return None
 
-    def get_collection_of_primitive_values(self, primitive_type) -> List[T]:
+    def get_collection_of_primitive_values(self, primitive_type: type[T]) -> List[T]:
         """Gets the collection of primitive values of the node
         Args:
             primitive_type: The type of primitive to return.
@@ -142,7 +142,7 @@ class TextParseNode(ParseNode):
         """
         raise Exception(self.NO_STRUCTURED_DATA_MESSAGE)
 
-    def get_collection_of_object_values(self, factory: ParsableFactory) -> List[U]:
+    def get_collection_of_object_values(self, factory: ParsableFactory[U]) -> List[U]:
         """Gets the collection of type U values from the text node
         Returns:
             List[U]: The collection of model object values of the node


### PR DESCRIPTION
Related to https://github.com/microsoft/kiota/pull/5729

Fixes failures in integration tests due to mypy failures in incorrect typing information for the following methods,

- `send_collection_of_primitive_async` from `RequestAdapter` should have the `type` as the parameter type for ResponseType
- Cleans up `set_content_from_parsable` to target parsable so that `set_content_from_scalar` can target scalars
- adds missing type info for `get_collection_of_primitive_values` as well as the derived implementations
- adds missing type info for `get_collection_of_object_values` as well as the derived implementations