### PR TITLE
Bugfix: CHANGELOG and LICENSE files are saving to the root site-packages dir

### DIFF
--- a/packages/abstractions/pyproject.toml
+++ b/packages/abstractions/pyproject.toml
@@ -22,7 +22,6 @@ homepage = "https://github.com/microsoft/kiota#readme"
 repository = "https://github.com/microsoft/kiota-python"
 documentation = "https://microsoft.github.io/kiota/"
 packages = [{include = "kiota_abstractions"}]
-include = ["CHANGELOG.md", "LICENSE"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"

--- a/packages/authentication/azure/pyproject.toml
+++ b/packages/authentication/azure/pyproject.toml
@@ -21,8 +21,7 @@ classifiers = [
 homepage = "https://github.com/microsoft/kiota#readme"
 repository = "https://github.com/microsoft/kiota-python"
 documentation = "https://microsoft.github.io/kiota/"
-packages = [{include = "kiota_authentication_azure"}]	
-include = ["CHANGELOG.md", "LICENSE"]
+packages = [{include = "kiota_authentication_azure"}]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"

--- a/packages/bundle/pyproject.toml
+++ b/packages/bundle/pyproject.toml
@@ -23,7 +23,6 @@ homepage = "https://github.com/microsoft/kiota#readme"
 repository = "https://github.com/microsoft/kiota-python"
 documentation = "https://microsoft.github.io/kiota/"
 packages = [{include = "kiota_bundle"}]
-include = ["CHANGELOG.md", "LICENSE"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"

--- a/packages/http/httpx/pyproject.toml
+++ b/packages/http/httpx/pyproject.toml
@@ -23,7 +23,6 @@ homepage = "https://github.com/microsoft/kiota#readme"
 repository = "https://github.com/microsoft/kiota-python"
 documentation = "https://microsoft.github.io/kiota/"
 packages = [{include = "kiota_http"}]
-include = ["CHANGELOG.md", "LICENSE"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"

--- a/packages/serialization/form/pyproject.toml
+++ b/packages/serialization/form/pyproject.toml
@@ -22,7 +22,6 @@ homepage = "https://github.com/microsoft/kiota#readme"
 repository = "https://github.com/microsoft/kiota-python"
 documentation = "https://microsoft.github.io/kiota/"
 packages = [{include = "kiota_serialization_form"}]
-include = ["CHANGELOG.md", "LICENSE"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"

--- a/packages/serialization/json/pyproject.toml
+++ b/packages/serialization/json/pyproject.toml
@@ -22,7 +22,6 @@ homepage = "https://github.com/microsoft/kiota#readme"
 repository = "https://github.com/microsoft/kiota-python"
 documentation = "https://microsoft.github.io/kiota/"
 packages = [{include = "kiota_serialization_json"}]
-include = ["CHANGELOG.md", "LICENSE"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"

--- a/packages/serialization/multipart/pyproject.toml
+++ b/packages/serialization/multipart/pyproject.toml
@@ -22,7 +22,6 @@ homepage = "https://github.com/microsoft/kiota#readme"
 repository = "https://github.com/microsoft/kiota-python"
 documentation = "https://microsoft.github.io/kiota/"
 packages = [{include = "kiota_serialization_multipart"}]
-include = ["CHANGELOG.md", "LICENSE"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"

--- a/packages/serialization/text/pyproject.toml
+++ b/packages/serialization/text/pyproject.toml
@@ -22,7 +22,6 @@ homepage = "https://github.com/microsoft/kiota#readme"
 repository = "https://github.com/microsoft/kiota-python"
 documentation = "https://microsoft.github.io/kiota/"
 packages = [{include = "kiota_serialization_text"}]
-include = ["CHANGELOG.md", "LICENSE"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"


### PR DESCRIPTION
## Overview
As the title says, `CHANGELOG.md` and `LICENSE` files are saving to the root `site-packages` dir. If you install all the serialization packages, these 2 files get overwritten a few times. Then when uninstalling (or running `poetry update` for that matter) you quickly run into `FileNotFoundError` errors and poetry telling you `Cannot install microsoft-kiota-serialization-text` or any of the other ones.

## Proposed Solution
* **For license**, you don't even need to include it in the `include`, it gets detected automatically and is included within the package. ([here](https://github.com/python-poetry/poetry-core/blob/2cbe240beda1bb20eaf02a1ca0353b0ce6c167e6/src/poetry/core/masonry/builders/builder.py#L319-L327) are the files that get included automatically).
* **For changelog** you'd need to do [a clever hack like this](https://github.com/microbiomedata/submission-schema/pull/187) if you really, really want to include it in the python package. I'd recommend just not including changelog in the python package, I can't conceive a reason why the functional code would need it, so this PR omits it rather than employing any clever hacks


## Related Issue

Fixes #406 

### Notes
* [Here's a poetry github issue](https://github.com/python-poetry/poetry/issues/7153) describing how poetry does exactly what is causing this issue (which sounds like it won't be fixed/changed)
* [Here's a workaround](https://github.com/microbiomedata/submission-schema/pull/187) if you really want to include some files anyway

## Testing Instructions

No testing required