### PR TITLE
Fixes Retry Handler delay validation, retry count validation and exponential backoff

### DIFF
--- a/packages/http/httpx/kiota_http/middleware/retry_handler.py
+++ b/packages/http/httpx/kiota_http/middleware/retry_handler.py
@@ -88,7 +88,7 @@ class RetryHandler(BaseMiddleware):
             retry_valid = self.check_retry_valid(retry_count, current_options)
 
             # Get the delay time between retries
-            delay = self.get_delay_time(retry_count, response)
+            delay = self.get_delay_time(retry_count, response, current_options.max_delay)
 
             # Check if the request needs to be retried based on the response method
             # and status code
@@ -165,7 +165,7 @@ class RetryHandler(BaseMiddleware):
             return True
         return False
 
-    def get_delay_time(self, retry_count, response=None):
+    def get_delay_time(self, retry_count, response=None, delay=0):
         """
         Get the time in seconds to delay between retry attempts.
         Respects a retry-after header in the response if provided
@@ -174,15 +174,15 @@ class RetryHandler(BaseMiddleware):
         retry_after = self._get_retry_after(response)
         if retry_after:
             return retry_after
-        return self._get_delay_time_exp_backoff(retry_count)
+        return self._get_delay_time_exp_backoff(retry_count, delay)
 
-    def _get_delay_time_exp_backoff(self, retry_count):
+    def _get_delay_time_exp_backoff(self, retry_count, delay):
         """
         Get time in seconds to delay between retry attempts based on an exponential
         backoff value.
         """
         exp_backoff_value = self.backoff_factor * +(2**(retry_count - 1))
-        backoff_value = exp_backoff_value + (random.randint(0, 1000) / 1000)
+        backoff_value = exp_backoff_value + (random.randint(0, 1000) / 1000) + delay
 
         backoff = min(self.backoff_max, backoff_value)
         return backoff

--- a/packages/http/httpx/kiota_http/middleware/retry_handler.py
+++ b/packages/http/httpx/kiota_http/middleware/retry_handler.py
@@ -95,7 +95,7 @@ class RetryHandler(BaseMiddleware):
             # Check if the request needs to be retried based on the response method
             # and status code
             should_retry = self.should_retry(request, current_options, response)
-            if all([should_retry, retry_valid, delay < max_delay]):
+            if all([should_retry, retry_valid, delay < RetryHandlerOption.MAX_DELAY]):
                 time.sleep(delay)
                 end_time = time.time()
                 max_delay -= (end_time - start_time)

--- a/packages/http/httpx/tests/middleware_tests/test_retry_handler.py
+++ b/packages/http/httpx/tests/middleware_tests/test_retry_handler.py
@@ -224,9 +224,10 @@ async def test_returns_same_status_code_if_delay_greater_than_max_delay():
             return httpx.Response(200, )
         return httpx.Response(
             TOO_MANY_REQUESTS,
-            headers={RETRY_AFTER: "20"},
+            headers={RETRY_AFTER: "200"}, # value exceeds max delay of 180 secs
         )
 
+    # Retry-after value takes precedence over the RetryHandlerOption value specified here
     handler = RetryHandler(RetryHandlerOption(10, 1, True))
     request = httpx.Request(
         'GET',

--- a/packages/http/httpx/tests/middleware_tests/test_retry_handler.py
+++ b/packages/http/httpx/tests/middleware_tests/test_retry_handler.py
@@ -238,6 +238,29 @@ async def test_returns_same_status_code_if_delay_greater_than_max_delay():
     assert resp.status_code == 429
     assert RETRY_ATTEMPT not in resp.request.headers
 
+@pytest.mark.asyncio
+async def test_max_retries_respected():
+    """Test that a request is not retried more than max_retries configured"""
+
+    def request_handler(request: httpx.Request):
+        if RETRY_ATTEMPT in request.headers:
+            return httpx.Response(200, )
+        return httpx.Response(
+            TOO_MANY_REQUESTS,
+        )
+
+    # Retry-after value takes precedence over the RetryHandlerOption value specified here
+    handler = RetryHandler(RetryHandlerOption(10, 3, True))
+    request = httpx.Request(
+        'GET',
+        BASE_URL,
+        headers={RETRY_ATTEMPT: '5'} # value exceeds max retries configured
+    )
+    mock_transport = httpx.MockTransport(request_handler)
+    resp = await handler.send(request, mock_transport)
+    assert resp.status_code == 200
+    assert RETRY_ATTEMPT in resp.request.headers
+    assert resp.request.headers[RETRY_ATTEMPT] == '5'
 
 @pytest.mark.asyncio
 async def test_retry_options_apply_per_request():


### PR DESCRIPTION
- Ensure calculated retry delay validated against correct maximum delay of 180 secs
-  Fixes retry handler exponential back-off to consider the delay specified in the retry handler option
- Ensures retry count is incremented based on value in retry-attempt header to prevent exceeding configured max retries

closes https://github.com/microsoft/kiota-python/issues/409