### PR TITLE
fix: Regex extracting claims (addressing #420)

### DIFF
--- a/packages/http/httpx/kiota_http/httpx_request_adapter.py
+++ b/packages/http/httpx/kiota_http/httpx_request_adapter.py
@@ -564,10 +564,10 @@ class HttpxRequestAdapter(RequestAdapter):
             if auth_header_value.casefold().startswith(
                 self.BEARER_AUTHENTICATION_SCHEME.casefold()
             ):
-                claims_match = re.search('claims="(.+)"', auth_header_value)
+                claims_match = re.search('claims="([^"]+)"', auth_header_value)
                 if not claims_match:
                     raise ValueError("Unable to parse claims from response")
-                response_claims = claims_match.group().split('="')[1]
+                response_claims = claims_match.group(1)
                 parent_span.add_event(AUTHENTICATE_CHALLENGED_EVENT_KEY)
                 parent_span.set_attribute("http.retry_count", 1)
                 return await self.get_http_response_message(

--- a/packages/http/httpx/tests/test_httpx_request_adapter.py
+++ b/packages/http/httpx/tests/test_httpx_request_adapter.py
@@ -394,7 +394,7 @@ async def test_retries_on_cae_failure(
             {
                 "claims": (
                     "eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbH"
-                    "VlIjoiMTYwNDEwNjY1MSJ9fX0"
+                    "VlIjoiMTYwNDEwNjY1MSJ9fX0="
                 )
             },
         ),


### PR DESCRIPTION
## Overview

Updates the regex extracting the base-64 encoded claims in the WWW-Authenticate header. More details provided in issue #420.

## Related Issue

Fixes #420