### PR TITLE
Update json_parse_node.py

### DIFF
--- a/packages/serialization/json/kiota_serialization_json/json_parse_node.py
+++ b/packages/serialization/json/kiota_serialization_json/json_parse_node.py
@@ -312,7 +312,8 @@ class JsonParseNode(ParseNode):
             try:
                 if self.__is_four_digit_number(value):
                     return value
-
+                if value.isdigit():
+                    return value
                 datetime_obj = pendulum.parse(value)
                 if isinstance(datetime_obj, pendulum.Duration):
                     return datetime_obj.as_timedelta()

--- a/packages/serialization/json/tests/unit/test_json_parse_node.py
+++ b/packages/serialization/json/tests/unit/test_json_parse_node.py
@@ -139,6 +139,25 @@ def test_get_anythin_does_not_convert_numeric_chars_to_datetime():
     assert result == "1212"
 
 
+def test_get_anythin_does_not_convert_any_length_numeric_chars_to_datetime():
+    parse_node = JsonParseNode("1212")
+    result1 = parse_node.try_get_anything("1212")
+    parse_node_two = JsonParseNode("-PT15M")
+    result2 = parse_node_two.try_get_anything("-PT15M")
+    parse_node_three = JsonParseNode("20081008")
+    result3 = parse_node_three.try_get_anything("20081008")
+    parse_node_four = JsonParseNode("1011317")
+    result4 = parse_node_four.try_get_anything("1011317")
+    assert isinstance(result1, str)
+    assert result1 == "1212"
+    assert isinstance(result2, str)
+    assert result2 == "-PT15M"
+    assert isinstance(result3, str)
+    assert result3 == "20081008"
+    assert isinstance(result4, str)
+    assert result4 == "1011317"
+
+
 def test_get_anythin_does_convert_date_string_to_datetime():
     parse_node = JsonParseNode("2023-10-05T14:48:00.000Z")
     result = parse_node.try_get_anything("2023-10-05T14:48:00.000Z")


### PR DESCRIPTION
Fixes numerical strings accidentally getting parsed to date

## Overview
There seems to be a problem in deserialization of numerical strings in the ms-graph-sdk, which in turn uses this SDK.
It was pointed out that the old serialization library had a patch applied
https://github.com/microsoft/kiota-serialization-json-python/pull/358/files
Which resolved the issue, but the ms-graph-sdk seems to now be using this repo, where the patch does not exist.

## Related Issue
https://github.com/microsoftgraph/msgraph-sdk-python/issues/1026

Fixes # (issue)
https://github.com/microsoftgraph/msgraph-sdk-python/issues/1026
