### PR TITLE
feat: drop support for python 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         library : 
           - name: "kiota_abstractions"
             path: "./packages/abstractions"
@@ -76,7 +76,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout

--- a/packages/abstractions/kiota_abstractions/api_client_builder.py
+++ b/packages/abstractions/kiota_abstractions/api_client_builder.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 from .serialization import (
     ParseNodeFactory,

--- a/packages/abstractions/kiota_abstractions/api_error.py
+++ b/packages/abstractions/kiota_abstractions/api_error.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Optional
 
 
 @dataclass
@@ -8,7 +8,7 @@ class APIError(Exception):
 
     message: Optional[str] = None
     response_status_code: Optional[int] = None
-    response_headers: Optional[Dict[str, str]] = None
+    response_headers: Optional[dict[str, str]] = None
 
     def __str__(self) -> str:
         error = getattr(self, "error", None)

--- a/packages/abstractions/kiota_abstractions/authentication/access_token_provider.py
+++ b/packages/abstractions/kiota_abstractions/authentication/access_token_provider.py
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any
 
 from .allowed_hosts_validator import AllowedHostsValidator
 
@@ -16,7 +16,7 @@ class AccessTokenProvider(ABC):
 
     @abstractmethod
     async def get_authorization_token(
-        self, uri: str, additional_authentication_context: Dict[str, Any] = {}
+        self, uri: str, additional_authentication_context: dict[str, Any] = {}
     ) -> str:
         """This method is called by the BaseBearerTokenAuthenticationProvider class to get the
         access token.

--- a/packages/abstractions/kiota_abstractions/authentication/allowed_hosts_validator.py
+++ b/packages/abstractions/kiota_abstractions/authentication/allowed_hosts_validator.py
@@ -1,4 +1,3 @@
-from typing import Set
 from urllib.parse import urlparse
 
 
@@ -17,7 +16,7 @@ class AllowedHostsValidator:
         if not isinstance(allowed_hosts, list):
             raise TypeError("Allowed hosts must be a list of strings")
 
-        self.allowed_hosts: Set[str] = {x.lower() for x in allowed_hosts}
+        self.allowed_hosts: set[str] = {x.lower() for x in allowed_hosts}
 
     def get_allowed_hosts(self) -> list[str]:
         """Gets the list of valid hosts.  If the list is empty, all hosts are valid.

--- a/packages/abstractions/kiota_abstractions/authentication/allowed_hosts_validator.py
+++ b/packages/abstractions/kiota_abstractions/authentication/allowed_hosts_validator.py
@@ -1,4 +1,4 @@
-from typing import List, Set
+from typing import Set
 from urllib.parse import urlparse
 
 
@@ -7,11 +7,11 @@ class AllowedHostsValidator:
     a host is valid before authenticating a request
     """
 
-    def __init__(self, allowed_hosts: List[str]) -> None:
+    def __init__(self, allowed_hosts: list[str]) -> None:
         """Creates a new AllowedHostsValidator object with provided values.
 
         Args:
-            allowed_hosts (List[str]): A list of valid hosts.  If the list is empty, all hosts
+            allowed_hosts (list[str]): A list of valid hosts.  If the list is empty, all hosts
             are valid.
         """
         if not isinstance(allowed_hosts, list):
@@ -19,19 +19,19 @@ class AllowedHostsValidator:
 
         self.allowed_hosts: Set[str] = {x.lower() for x in allowed_hosts}
 
-    def get_allowed_hosts(self) -> List[str]:
+    def get_allowed_hosts(self) -> list[str]:
         """Gets the list of valid hosts.  If the list is empty, all hosts are valid.
 
         Returns:
-            List[str]: A list of valid hosts.  If the list is empty, all hosts are valid.
+            list[str]: A list of valid hosts.  If the list is empty, all hosts are valid.
         """
         return list(self.allowed_hosts)
 
-    def set_allowed_hosts(self, allowed_hosts: List[str]) -> None:
+    def set_allowed_hosts(self, allowed_hosts: list[str]) -> None:
         """Sets the list of valid hosts.  If the list is empty, all hosts are valid.
 
         Args:
-            allowed_hosts (List[str]): A list of valid hosts.  If the list is empty, all hosts
+            allowed_hosts (list[str]): A list of valid hosts.  If the list is empty, all hosts
             are valid
         """
         if not isinstance(allowed_hosts, list):

--- a/packages/abstractions/kiota_abstractions/authentication/anonymous_authentication_provider.py
+++ b/packages/abstractions/kiota_abstractions/authentication/anonymous_authentication_provider.py
@@ -4,7 +4,7 @@
 # See License in the project root for license information.
 # ------------------------------------------------------------------------------
 
-from typing import Any, Dict
+from typing import Any
 
 from ..request_information import RequestInformation
 from .authentication_provider import AuthenticationProvider
@@ -20,7 +20,7 @@ class AnonymousAuthenticationProvider(AuthenticationProvider):
     async def authenticate_request(
         self,
         request: RequestInformation,
-        additional_authentication_context: Dict[str, Any] = {}
+        additional_authentication_context: dict[str, Any] = {}
     ) -> None:
         """Authenticates the provided request information
 

--- a/packages/abstractions/kiota_abstractions/authentication/api_key_authentication_provider.py
+++ b/packages/abstractions/kiota_abstractions/authentication/api_key_authentication_provider.py
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 from enum import Enum
-from typing import Any, List
+from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from kiota_abstractions.request_information import RequestInformation
@@ -33,7 +33,7 @@ class ApiKeyAuthenticationProvider(AuthenticationProvider):
         key_location: KeyLocation,
         api_key: str,
         parameter_name: str,
-        allowed_hosts: List[str] = [],
+        allowed_hosts: list[str] = [],
     ) -> None:
         if not isinstance(key_location, KeyLocation):
             err = "key_location can only be 'query_parameter' or 'header'"

--- a/packages/abstractions/kiota_abstractions/authentication/api_key_authentication_provider.py
+++ b/packages/abstractions/kiota_abstractions/authentication/api_key_authentication_provider.py
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any, List
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from kiota_abstractions.request_information import RequestInformation
@@ -56,7 +56,7 @@ class ApiKeyAuthenticationProvider(AuthenticationProvider):
     async def authenticate_request(
         self,
         request: RequestInformation,
-        additional_authentication_context: Dict[str, Any] = {}
+        additional_authentication_context: dict[str, Any] = {}
     ) -> None:
         """
         Ensures that the API key is placed in the correct location for a request.

--- a/packages/abstractions/kiota_abstractions/authentication/authentication_provider.py
+++ b/packages/abstractions/kiota_abstractions/authentication/authentication_provider.py
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any
 
 from ..request_information import RequestInformation
 
@@ -19,7 +19,7 @@ class AuthenticationProvider(ABC):
     async def authenticate_request(
         self,
         request: RequestInformation,
-        additional_authentication_context: Dict[str, Any] = {}
+        additional_authentication_context: dict[str, Any] = {}
     ) -> None:
         """Authenticates the application request
 

--- a/packages/abstractions/kiota_abstractions/authentication/base_bearer_token_authentication_provider.py
+++ b/packages/abstractions/kiota_abstractions/authentication/base_bearer_token_authentication_provider.py
@@ -4,7 +4,7 @@
 # See License in the project root for license information.
 # ------------------------------------------------------------------------------
 
-from typing import Any, Dict
+from typing import Any
 
 from ..headers_collection import HeadersCollection
 from ..request_information import RequestInformation
@@ -24,7 +24,7 @@ class BaseBearerTokenAuthenticationProvider(AuthenticationProvider):
     async def authenticate_request(
         self,
         request: RequestInformation,
-        additional_authentication_context: Dict[str, Any] = {}
+        additional_authentication_context: dict[str, Any] = {}
     ) -> None:
         """Authenticates the provided RequestInformation instance using the provided
         authorization token

--- a/packages/abstractions/kiota_abstractions/base_request_builder.py
+++ b/packages/abstractions/kiota_abstractions/base_request_builder.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # See License in the project root for license information.
 # ------------------------------------
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from .request_adapter import RequestAdapter
 from .request_information import RequestInformation
@@ -14,7 +14,7 @@ class BaseRequestBuilder:
 
     def __init__(
         self, request_adapter: RequestAdapter, url_template: str,
-        path_parameters: Optional[Union[Dict[str, Any], str]]
+        path_parameters: Optional[Union[dict[str, Any], str]]
     ) -> None:
         """Initializes a new instance of the BaseRequestBuilder class."""
         if path_parameters is None:
@@ -28,7 +28,7 @@ class BaseRequestBuilder:
             raise TypeError("url_template cannot be null.")  # Empty string is allowed
 
         # Path parameters for the request
-        self.path_parameters: Dict[str, Any] = path_parameters
+        self.path_parameters: dict[str, Any] = path_parameters
         # Url template to use to build the URL for the current request builder
         self.url_template: str = url_template
         # The request adapter to use to execute the requests.

--- a/packages/abstractions/kiota_abstractions/base_request_configuration.py
+++ b/packages/abstractions/kiota_abstractions/base_request_configuration.py
@@ -4,7 +4,7 @@
 # See License in the project root for license information.
 # ------------------------------------
 from dataclasses import dataclass
-from typing import Generic, List, Optional, TypeVar
+from typing import Generic, Optional, TypeVar
 from warnings import warn
 
 from .headers_collection import HeadersCollection
@@ -21,7 +21,7 @@ class RequestConfiguration(Generic[QueryParameters]):
     # Request headers
     headers: HeadersCollection = HeadersCollection()
     # Request options
-    options: Optional[List[RequestOption]] = None
+    options: Optional[list[RequestOption]] = None
     # Request query parameters
     query_parameters: Optional[QueryParameters] = None
 

--- a/packages/abstractions/kiota_abstractions/default_query_parameters.py
+++ b/packages/abstractions/kiota_abstractions/default_query_parameters.py
@@ -4,7 +4,6 @@
 # See License in the project root for license information.
 # ------------------------------------
 from dataclasses import dataclass
-from typing import List, Optional
 from warnings import warn
 
 

--- a/packages/abstractions/kiota_abstractions/get_path_parameters.py
+++ b/packages/abstractions/kiota_abstractions/get_path_parameters.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from .request_information import RequestInformation
 
 
-def get_path_parameters(parameters: Union[Dict[str, Any], Optional[str]]) -> Dict[str, Any]:
-    result: Dict[str, Any] = {}
+def get_path_parameters(parameters: Union[dict[str, Any], Optional[str]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
     if isinstance(parameters, str):
         result[RequestInformation.RAW_URL_KEY] = parameters
     elif isinstance(parameters, dict):

--- a/packages/abstractions/kiota_abstractions/headers_collection.py
+++ b/packages/abstractions/kiota_abstractions/headers_collection.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Set, Union
+from typing import Set, Union
 
 
 class HeadersCollection():
@@ -84,12 +84,12 @@ class HeadersCollection():
             for value in values:
                 self.add(key, value)
 
-    def add(self, header_name: str, header_values: Union[str, List[str]]) -> None:
+    def add(self, header_name: str, header_values: Union[str, list[str]]) -> None:
         """Adds values to the header with the specified name.
 
         Args:
             header_name (str): The name of the header to add values to.
-            header_values (List[str]): The values to add to the header.
+            header_values (list[str]): The values to add to the header.
         """
         if not header_name:
             raise ValueError("Header name cannot be null")
@@ -112,10 +112,10 @@ class HeadersCollection():
             else:
                 self._headers[header_name] = {header_values}
 
-    def keys(self) -> List[str]:
+    def keys(self) -> list[str]:
         """Gets the header names present in the collection.
         Returns:
-            List[str]: The header names present in the collection.
+            list[str]: The header names present in the collection.
         """
         return list(self._headers.keys())
 

--- a/packages/abstractions/kiota_abstractions/headers_collection.py
+++ b/packages/abstractions/kiota_abstractions/headers_collection.py
@@ -1,23 +1,23 @@
 from __future__ import annotations
 
-from typing import Set, Union
+from typing import Union
 
 
 class HeadersCollection():
     "Represents a collection of request/response headers"
-    SINGLE_VALUE_HEADERS: Set[str] = {"content-type", "content-encoding", "content-length"}
+    SINGLE_VALUE_HEADERS: set[str] = {"content-type", "content-encoding", "content-length"}
 
     def __init__(self) -> None:
-        self._headers: dict[str, Set[str]] = {}
+        self._headers: dict[str, set[str]] = {}
 
-    def try_get(self, key: str) -> Union[bool, Set[str]]:
+    def try_get(self, key: str) -> Union[bool, set[str]]:
         """Gets the header values corresponding to a specific header name.
 
         Args:
             key (str): Header key.
 
         Returns:
-            Union[bool, Set[str]]: The header values for the specified header key or False.
+            Union[bool, set[str]]: The header values for the specified header key or False.
         """
         if not key:
             raise ValueError("Header name cannot be null")
@@ -27,7 +27,7 @@ class HeadersCollection():
             return values
         return False
 
-    def get_all(self) -> dict[str, Set[str]]:
+    def get_all(self) -> dict[str, set[str]]:
         """Get all headers and values stored so far.
 
         Returns:
@@ -35,14 +35,14 @@ class HeadersCollection():
         """
         return self._headers
 
-    def get(self, header_name: str) -> Set[str]:
+    def get(self, header_name: str) -> set[str]:
         """Get header values corresponding to a specific header.
         
         Args:
             header_name (str): Header key.
 
         Returns:
-            Set[str]: Values for the header key
+            set[str]: Values for the header key
         """
         if not header_name:
             raise ValueError("Header name cannot be null")
@@ -123,7 +123,7 @@ class HeadersCollection():
         """Gets the number of headers present in the collection."""
         return len(self._headers)
 
-    def remove_value(self, header_name: str, header_value: str) -> Union[bool, Set[str]]:
+    def remove_value(self, header_name: str, header_value: str) -> Union[bool, set[str]]:
         """Removes the specified value from the header with the specified name.
 
         Args:
@@ -147,7 +147,7 @@ class HeadersCollection():
 
         return False
 
-    def remove(self, header_name: str) -> Union[bool, Set[str]]:
+    def remove(self, header_name: str) -> Union[bool, set[str]]:
         """Removes the header with the specified name.
 
         Args:

--- a/packages/abstractions/kiota_abstractions/headers_collection.py
+++ b/packages/abstractions/kiota_abstractions/headers_collection.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Set, Union
+from typing import List, Set, Union
 
 
 class HeadersCollection():
@@ -8,7 +8,7 @@ class HeadersCollection():
     SINGLE_VALUE_HEADERS: Set[str] = {"content-type", "content-encoding", "content-length"}
 
     def __init__(self) -> None:
-        self._headers: Dict[str, Set[str]] = {}
+        self._headers: dict[str, Set[str]] = {}
 
     def try_get(self, key: str) -> Union[bool, Set[str]]:
         """Gets the header values corresponding to a specific header name.
@@ -27,11 +27,11 @@ class HeadersCollection():
             return values
         return False
 
-    def get_all(self) -> Dict[str, Set[str]]:
+    def get_all(self) -> dict[str, Set[str]]:
         """Get all headers and values stored so far.
 
         Returns:
-            Dict[str, str]: The headers
+            dict[str, str]: The headers
         """
         return self._headers
 
@@ -76,7 +76,7 @@ class HeadersCollection():
         """Adds the specified headers to the collection.
 
         Args:
-            headers (Dict[str, str]): The headers to add.
+            headers (dict[str, str]): The headers to add.
         """
         if not headers:
             raise ValueError("Headers cannot be null")

--- a/packages/abstractions/kiota_abstractions/multipart_body.py
+++ b/packages/abstractions/kiota_abstractions/multipart_body.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 import io
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, Tuple, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
 
 from .serialization import Parsable
 
@@ -32,7 +33,7 @@ class MultipartBody(Parsable, Generic[T]):
             multipart.serialize(output_file)
     """
     boundary: str = str(uuid.uuid4())
-    parts: dict[str, Tuple[str, Any, Optional[str]]] = field(default_factory=dict)
+    parts: dict[str, tuple[str, Any, Optional[str]]] = field(default_factory=dict)
     request_adapter: Optional[RequestAdapter] = None
 
     def add_or_replace_part(
@@ -59,7 +60,7 @@ class MultipartBody(Parsable, Generic[T]):
             raise ValueError("Content type cannot be null")
         if not part_value:
             raise ValueError("Part value cannot be null")
-        value: Tuple[str, Any, Optional[str]] = (content_type, part_value, filename)
+        value: tuple[str, Any, Optional[str]] = (content_type, part_value, filename)
         self.parts[self._normalize_part_name(part_name)] = value
 
     def get_part_value(self, part_name: str) -> Optional[T]:
@@ -139,7 +140,7 @@ class MultipartBody(Parsable, Generic[T]):
         writer.write_str_value("", "")
 
     def _get_comtent_disposition(
-        self, part_name: str, part_value: Tuple[str, Any, Optional[str]]
+        self, part_name: str, part_value: tuple[str, Any, Optional[str]]
     ) -> str:
         if len(part_value) >= 3 and part_value[2] is not None:
             return f'form-data; name="{part_name}"; filename="{part_value[2]}"'

--- a/packages/abstractions/kiota_abstractions/multipart_body.py
+++ b/packages/abstractions/kiota_abstractions/multipart_body.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import io
 import uuid
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, Optional, Tuple, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, Tuple, TypeVar
 
 from .serialization import Parsable
 
@@ -32,7 +32,7 @@ class MultipartBody(Parsable, Generic[T]):
             multipart.serialize(output_file)
     """
     boundary: str = str(uuid.uuid4())
-    parts: Dict[str, Tuple[str, Any, Optional[str]]] = field(default_factory=dict)
+    parts: dict[str, Tuple[str, Any, Optional[str]]] = field(default_factory=dict)
     request_adapter: Optional[RequestAdapter] = None
 
     def add_or_replace_part(
@@ -82,11 +82,11 @@ class MultipartBody(Parsable, Generic[T]):
             raise ValueError("Part name cannot be null")
         return self.parts.pop(self._normalize_part_name(part_name), None) is not None
 
-    def get_field_deserializers(self) -> Dict[str, Callable[[ParseNode], None]]:
+    def get_field_deserializers(self) -> dict[str, Callable[[ParseNode], None]]:
         """Gets the deserialization information for this object.
 
         Returns:
-            Dict[str, Callable[[ParseNode], None]]: The deserialization information for this
+            dict[str, Callable[[ParseNode], None]]: The deserialization information for this
             object where each entry is a property key with its deserialization callback.
         """
         raise NotImplementedError()

--- a/packages/abstractions/kiota_abstractions/native_response_handler.py
+++ b/packages/abstractions/kiota_abstractions/native_response_handler.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, TypeVar
+from typing import Optional, TypeVar
 
 from .response_handler import ResponseHandler
 from .serialization import ParsableFactory
@@ -14,12 +14,12 @@ class NativeResponseHandler(ResponseHandler):
     async def handle_response_async(
         self,
         response: NativeResponseType,
-        error_map: Optional[Dict[str, ParsableFactory]] = None
+        error_map: Optional[dict[str, ParsableFactory]] = None
     ) -> NativeResponseType:
         """Callback method that is invoked when a response is received.
         Args:
             response (NativeResponseType): The type of the native response object.
-            error_map (Optional[Dict[str, ParsableFactory]]): the error dict to use
+            error_map (Optional[dict[str, ParsableFactory]]): the error dict to use
             in case of a failed request.
         Returns:
             Any: The native response object.

--- a/packages/abstractions/kiota_abstractions/request_adapter.py
+++ b/packages/abstractions/kiota_abstractions/request_adapter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import date, datetime, time, timedelta
 from io import BytesIO
-from typing import Dict, Generic, List, Optional, TypeVar, Union
+from typing import Generic, List, Optional, TypeVar, Union
 from uuid import UUID
 
 from .request_information import RequestInformation
@@ -36,7 +36,7 @@ class RequestAdapter(ABC, Generic[RequestType]):
     @abstractmethod
     async def send_async(
         self, request_info: RequestInformation, parsable_factory: ParsableFactory[ModelType],
-        error_map: Optional[Dict[str, type[ParsableFactory]]]
+        error_map: Optional[dict[str, type[ParsableFactory]]]
     ) -> Optional[ModelType]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
         deserialized response model.
@@ -45,7 +45,7 @@ class RequestAdapter(ABC, Generic[RequestType]):
             request_info (RequestInformation): the request info to execute.
             parsable_factory (ParsableFactory): the class of response model to
                 deserialize the response into.
-            error_map (Optional[Dict[str, type[ParsableFactory]]]): the error dict to use in case
+            error_map (Optional[dict[str, type[ParsableFactory]]]): the error dict to use in case
             of a failed request.
 
         Returns:
@@ -58,7 +58,7 @@ class RequestAdapter(ABC, Generic[RequestType]):
         self,
         request_info: RequestInformation,
         parsable_factory: ParsableFactory[ModelType],
-        error_map: Optional[Dict[str, type[ParsableFactory]]],
+        error_map: Optional[dict[str, type[ParsableFactory]]],
     ) -> Optional[List[ModelType]]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
         deserialized response model collection.
@@ -67,7 +67,7 @@ class RequestAdapter(ABC, Generic[RequestType]):
             request_info (RequestInformation): the request info to execute.
             parsable_factory (ParsableFactory): the class of response model to
                 deserialize the response into.
-            error_map (Optional[Dict[str, type[ParsableFactory]]]): the error dict to use in
+            error_map (Optional[dict[str, type[ParsableFactory]]]): the error dict to use in
             case of a failed request.
 
         Returns:
@@ -80,7 +80,7 @@ class RequestAdapter(ABC, Generic[RequestType]):
         self,
         request_info: RequestInformation,
         response_type: type[PrimitiveType],
-        error_map: Optional[Dict[str, type[ParsableFactory]]],
+        error_map: Optional[dict[str, type[ParsableFactory]]],
     ) -> Optional[List[PrimitiveType]]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
         deserialized response model collection.
@@ -89,7 +89,7 @@ class RequestAdapter(ABC, Generic[RequestType]):
             request_info (RequestInformation): the request info to execute.
             response_type (PrimitiveType): the class of the response model to deserialize the
             response into.
-            error_map (Optional[Dict[str, type[ParsableFactory]]]): the error dict to use in
+            error_map (Optional[dict[str, type[ParsableFactory]]]): the error dict to use in
             case of a failed request.
 
         Returns:
@@ -100,7 +100,7 @@ class RequestAdapter(ABC, Generic[RequestType]):
     @abstractmethod
     async def send_primitive_async(
         self, request_info: RequestInformation, response_type: str,
-        error_map: Optional[Dict[str, type[ParsableFactory]]]
+        error_map: Optional[dict[str, type[ParsableFactory]]]
     ) -> Optional[ResponseType]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
         deserialized primitive response model.
@@ -109,7 +109,7 @@ class RequestAdapter(ABC, Generic[RequestType]):
             request_info (RequestInformation): the request info to execute.
             response_type (str): the class name of the response model to deserialize the
             response into.
-            error_map (Optional[Dict[str, type[ParsableFactory]]]): the error dict to use in
+            error_map (Optional[dict[str, type[ParsableFactory]]]): the error dict to use in
             case of a failed request.
 
         Returns:
@@ -119,7 +119,7 @@ class RequestAdapter(ABC, Generic[RequestType]):
 
     @abstractmethod
     async def send_no_response_content_async(
-        self, request_info: RequestInformation, error_map: Optional[Dict[str,
+        self, request_info: RequestInformation, error_map: Optional[dict[str,
                                                                          type[ParsableFactory]]]
     ) -> None:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
@@ -127,7 +127,7 @@ class RequestAdapter(ABC, Generic[RequestType]):
 
         Args:
             request_info (RequestInformation):the request info to execute.
-            error_map (Optional[Dict[str, type[ParsableFactory]]]): the error dict to use in
+            error_map (Optional[dict[str, type[ParsableFactory]]]): the error dict to use in
             case of a failed request.
         """
         pass

--- a/packages/abstractions/kiota_abstractions/request_adapter.py
+++ b/packages/abstractions/kiota_abstractions/request_adapter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import date, datetime, time, timedelta
 from io import BytesIO
-from typing import Generic, List, Optional, TypeVar, Union
+from typing import Generic, Optional, TypeVar, Union
 from uuid import UUID
 
 from .request_information import RequestInformation
@@ -59,7 +59,7 @@ class RequestAdapter(ABC, Generic[RequestType]):
         request_info: RequestInformation,
         parsable_factory: ParsableFactory[ModelType],
         error_map: Optional[dict[str, type[ParsableFactory]]],
-    ) -> Optional[List[ModelType]]:
+    ) -> Optional[list[ModelType]]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
         deserialized response model collection.
 
@@ -81,7 +81,7 @@ class RequestAdapter(ABC, Generic[RequestType]):
         request_info: RequestInformation,
         response_type: type[PrimitiveType],
         error_map: Optional[dict[str, type[ParsableFactory]]],
-    ) -> Optional[List[PrimitiveType]]:
+    ) -> Optional[list[PrimitiveType]]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
         deserialized response model collection.
 
@@ -93,7 +93,7 @@ class RequestAdapter(ABC, Generic[RequestType]):
             case of a failed request.
 
         Returns:
-            Optional[List[PrimitiveType]]: The deserialized primitive collection.
+            Optional[list[PrimitiveType]]: The deserialized primitive collection.
         """
         pass
 

--- a/packages/abstractions/kiota_abstractions/request_adapter.py
+++ b/packages/abstractions/kiota_abstractions/request_adapter.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from datetime import date, datetime, time, timedelta
 from io import BytesIO

--- a/packages/abstractions/kiota_abstractions/request_information.py
+++ b/packages/abstractions/kiota_abstractions/request_information.py
@@ -9,7 +9,7 @@ from dataclasses import fields, is_dataclass
 from datetime import date, datetime, time, timedelta, timezone
 from enum import Enum
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Set, TypeVar, Union
 from urllib.parse import unquote
 from uuid import UUID
 
@@ -47,23 +47,23 @@ class RequestInformation:
         self,
         method: Optional[Method] = None,
         url_template: Optional[str] = None,
-        path_parameters: Dict[str, Any] = {}
+        path_parameters: dict[str, Any] = {}
     ) -> None:
         """Creates a new instance of the RequestInformation class.
 
         Args:
             method (Method): The request method.
             url_template (str): The given url template.
-            path_parameters (Dict[str, Any], optional): Path parameters
+            path_parameters (dict[str, Any], optional): Path parameters
             for the request. Defaults to {}.
         """
         # The uri of the request
         self.__uri: Optional[Url] = None
 
-        self.__request_options: Dict[str, RequestOption] = {}
+        self.__request_options: dict[str, RequestOption] = {}
 
         # The path parameters for the current request
-        self.path_parameters: Dict[str, Any] = path_parameters
+        self.path_parameters: dict[str, Any] = path_parameters
 
         # The URL template for the request
         self.url_template: Optional[str] = url_template
@@ -72,7 +72,7 @@ class RequestInformation:
         self.http_method: Optional[Method] = method
 
         # The query parameters for the request
-        self.query_parameters: Dict[str, Any] = {}
+        self.query_parameters: dict[str, Any] = {}
 
         # The Request Headers
         self.headers: HeadersCollection = HeadersCollection()
@@ -108,7 +108,7 @@ class RequestInformation:
         if not self.url_template:
             raise Exception("Url Template cannot be null")
 
-        data: Dict[str, Any] = {}
+        data: dict[str, Any] = {}
         for key, val in self.query_parameters.items():
             val = self._get_sanitized_value(val)
             data[key] = val
@@ -129,14 +129,14 @@ class RequestInformation:
         self.path_parameters.clear()
 
     @property
-    def request_headers(self) -> Optional[Dict]:
+    def request_headers(self) -> Optional[dict]:
         final = {}
         for key, values in self.headers.get_all().items():
             final[key] = ', '.join(values)
         return final
 
     @property
-    def request_options(self) -> Dict[str, RequestOption]:
+    def request_options(self) -> dict[str, RequestOption]:
         """Gets the request options for the request."""
         return self.__request_options
 
@@ -205,7 +205,7 @@ class RequestInformation:
                 writer.writer = writer.write_collection_of_primitive_values(None, values)
                 span.set_attribute(self.REQUEST_TYPE_KEY, "[]")
             else:
-                function_values: Dict[type, Callable] = {
+                function_values: dict[type, Callable] = {
                     bool: writer.write_bool_value,
                     str: writer.write_str_value,
                     int: writer.write_int_value,

--- a/packages/abstractions/kiota_abstractions/request_information.py
+++ b/packages/abstractions/kiota_abstractions/request_information.py
@@ -9,7 +9,7 @@ from dataclasses import fields, is_dataclass
 from datetime import date, datetime, time, timedelta, timezone
 from enum import Enum
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Set, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
 from urllib.parse import unquote
 from uuid import UUID
 
@@ -140,13 +140,13 @@ class RequestInformation:
         """Gets the request options for the request."""
         return self.__request_options
 
-    def add_request_options(self, options: Optional[List[RequestOption]]) -> None:
+    def add_request_options(self, options: Optional[list[RequestOption]]) -> None:
         if not options:
             return
         for option in options:
             self.__request_options[option.get_key()] = option
 
-    def remove_request_options(self, options: List[RequestOption]) -> None:
+    def remove_request_options(self, options: list[RequestOption]) -> None:
         if not options:
             return
         for option in options:
@@ -156,7 +156,7 @@ class RequestInformation:
         self,
         request_adapter: RequestAdapter,
         content_type: str,
-        values: Union[U, List[U]],
+        values: Union[U, list[U]],
     ) -> None:
         """Sets the request body from a model with the specified content type.
 
@@ -164,7 +164,7 @@ class RequestInformation:
             request_adapter (Optional[RequestAdapter]): The adapter service to get the serialization
             writer from.
             content_type (Optional[str]): the content type.
-            values (Union[U, List[U]]): the models.
+            values (Union[U, list[U]]): the models.
         """
         with tracer.start_as_current_span(
             self._create_parent_span_name("set_content_from_parsable")
@@ -186,7 +186,7 @@ class RequestInformation:
         self,
         request_adapter: Optional["RequestAdapter"],
         content_type: Optional[str],
-        values: Union[T, List[T]],
+        values: Union[T, list[T]],
     ) -> None:
         """Sets the request body from a scalar value with the specified content type.
 
@@ -194,7 +194,7 @@ class RequestInformation:
             request_adapter (Optional[RequestAdapter]): The adapter service to get the serialization
             writer from.
             content_type (Optional[str]): the content type to set.
-            values (Union[T, List[T]]): the scalar values to serialize
+            values (Union[T, list[T]]): the scalar values to serialize
         """
         with tracer.start_as_current_span(
             self._create_parent_span_name("set_content_from_scalar")

--- a/packages/abstractions/kiota_abstractions/request_information.py
+++ b/packages/abstractions/kiota_abstractions/request_information.py
@@ -5,11 +5,12 @@
 # ------------------------------------
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import fields, is_dataclass
 from datetime import date, datetime, time, timedelta, timezone
 from enum import Enum
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
 from urllib.parse import unquote
 from uuid import UUID
 

--- a/packages/abstractions/kiota_abstractions/response_handler.py
+++ b/packages/abstractions/kiota_abstractions/response_handler.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, TypeVar
+from typing import Any, Optional, TypeVar
 
 from .serialization import Parsable, ParsableFactory
 
@@ -13,12 +13,12 @@ class ResponseHandler(ABC):
 
     @abstractmethod
     async def handle_response_async(
-        self, response: NativeResponseType, error_map: Optional[Dict[str, ParsableFactory]]
+        self, response: NativeResponseType, error_map: Optional[dict[str, ParsableFactory]]
     ) -> Any:
         """Callback method that is invoked when a response is received.
         Args:
             response (NativeResponseType): The type of the native response object.
-            error_map (Optional[Dict[str, ParsableFactory]]]): the error dict to use
+            error_map (Optional[dict[str, ParsableFactory]]]): the error dict to use
             in case of a failed request.
         Returns:
             Any: The deserialized response.

--- a/packages/abstractions/kiota_abstractions/serialization/additional_data_holder.py
+++ b/packages/abstractions/kiota_abstractions/serialization/additional_data_holder.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from typing import Any
 
 
 @dataclass
@@ -7,4 +7,4 @@ class AdditionalDataHolder:
     """Defines a contract for models that can hold additional data besides the described properties.
     """
     # Stores the additional data for this object that did not belong to the properties.
-    additional_data: Dict[str, Any] = field(default_factory=dict)
+    additional_data: dict[str, Any] = field(default_factory=dict)

--- a/packages/abstractions/kiota_abstractions/serialization/parsable.py
+++ b/packages/abstractions/kiota_abstractions/serialization/parsable.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Dict, TypeVar
+from typing import TYPE_CHECKING, Callable, TypeVar
 
 T = TypeVar("T")
 
@@ -16,11 +16,11 @@ class Parsable(ABC):
     """
 
     @abstractmethod
-    def get_field_deserializers(self) -> Dict[str, Callable[['ParseNode'], None]]:
+    def get_field_deserializers(self) -> dict[str, Callable[['ParseNode'], None]]:
         """Gets the deserialization information for this object.
 
         Returns:
-            Dict[str, Callable[[ParseNode], None]]: The deserialization information for this
+            dict[str, Callable[[ParseNode], None]]: The deserialization information for this
             object where each entry is a property key with its deserialization callback.
         """
         pass

--- a/packages/abstractions/kiota_abstractions/serialization/parsable.py
+++ b/packages/abstractions/kiota_abstractions/serialization/parsable.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 T = TypeVar("T")
 

--- a/packages/abstractions/kiota_abstractions/serialization/parse_node.py
+++ b/packages/abstractions/kiota_abstractions/serialization/parse_node.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, Optional, TypeVar
+from typing import TYPE_CHECKING, Optional, TypeVar
 from uuid import UUID
 
 from .parsable import Parsable

--- a/packages/abstractions/kiota_abstractions/serialization/parse_node.py
+++ b/packages/abstractions/kiota_abstractions/serialization/parse_node.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Callable, Optional, TypeVar
 from uuid import UUID
 
 from .parsable import Parsable
@@ -118,31 +118,31 @@ class ParseNode(ABC):
         pass
 
     @abstractmethod
-    def get_collection_of_primitive_values(self, primitive_type: type[T]) -> Optional[List[T]]:
+    def get_collection_of_primitive_values(self, primitive_type: type[T]) -> Optional[list[T]]:
         """Gets the collection of primitive values of the node
         Args:
             primitive_type: The type of primitive to return.
         Returns:
-            List[T]: The collection of primitive values
+            list[T]: The collection of primitive values
         """
         pass
 
     @abstractmethod
-    def get_collection_of_object_values(self, factory: ParsableFactory[U]) -> Optional[List[U]]:
+    def get_collection_of_object_values(self, factory: ParsableFactory[U]) -> Optional[list[U]]:
         """Gets the collection of model object values of the node
         Args:
             factory (ParsableFactory): The factory to use to create the model object.
         Returns:
-            List[U]: The collection of model object values of the node
+            list[U]: The collection of model object values of the node
         """
         pass
 
     @abstractmethod
-    def get_collection_of_enum_values(self, enum_class: K) -> Optional[List[K]]:
+    def get_collection_of_enum_values(self, enum_class: K) -> Optional[list[K]]:
         """Gets the collection of enum values of the node
 
         Returns:
-            List[K]: The collection of enum values
+            list[K]: The collection of enum values
         """
         pass
 

--- a/packages/abstractions/kiota_abstractions/serialization/parse_node_factory_registry.py
+++ b/packages/abstractions/kiota_abstractions/serialization/parse_node_factory_registry.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-from typing import Dict
 
 from .parse_node import ParseNode
 from .parse_node_factory import ParseNodeFactory
@@ -10,7 +9,7 @@ from .parse_node_factory import ParseNodeFactory
 class ParseNodeFactoryRegistry(ParseNodeFactory):
     """Holds a list of all the registered factories for the various types of nodes
     """
-    CONTENT_TYPE_ASSOCIATED_FACTORIES: Dict[str, ParseNodeFactory] = {}
+    CONTENT_TYPE_ASSOCIATED_FACTORIES: dict[str, ParseNodeFactory] = {}
 
     __instance = None
 

--- a/packages/abstractions/kiota_abstractions/serialization/parse_node_helper.py
+++ b/packages/abstractions/kiota_abstractions/serialization/parse_node_helper.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 if TYPE_CHECKING:
     from . import Parsable, ParseNode
@@ -11,14 +11,14 @@ class ParseNodeHelper:
     @staticmethod
     def merge_deserializers_for_intersection_wrapper(
         *targets: Optional[Parsable]
-    ) -> Dict[str, Callable[[ParseNode], None]]:
+    ) -> dict[str, Callable[[ParseNode], None]]:
         """Merges a collection of parsable field deserializers into a single collection.
 
         Args:
             targets (tuple[Parsable, ...]):
 
         Returns:
-            Dict[str, Callable[[ParseNode], None]]:
+            dict[str, Callable[[ParseNode], None]]:
         """
         if not targets:
             raise TypeError("targets cannot be null.")

--- a/packages/abstractions/kiota_abstractions/serialization/parse_node_helper.py
+++ b/packages/abstractions/kiota_abstractions/serialization/parse_node_helper.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Optional
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from . import Parsable, ParseNode

--- a/packages/abstractions/kiota_abstractions/serialization/parse_node_proxy_factory.py
+++ b/packages/abstractions/kiota_abstractions/serialization/parse_node_proxy_factory.py
@@ -4,7 +4,7 @@
 # See License in the project root for license information.
 # ------------------------------------------------------------------------------
 
-from typing import Callable
+from collections.abc import Callable
 
 from .parsable import Parsable
 from .parse_node import ParseNode

--- a/packages/abstractions/kiota_abstractions/serialization/serialization_writer.py
+++ b/packages/abstractions/kiota_abstractions/serialization/serialization_writer.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Optional, TypeVar
 from uuid import UUID
 
 from .parsable import Parsable

--- a/packages/abstractions/kiota_abstractions/serialization/serialization_writer.py
+++ b/packages/abstractions/kiota_abstractions/serialization/serialization_writer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 from uuid import UUID
 
 from .parsable import Parsable
@@ -109,39 +109,39 @@ class SerializationWriter(ABC):
 
     @abstractmethod
     def write_collection_of_primitive_values(
-        self, key: Optional[str], values: Optional[List[T]]
+        self, key: Optional[str], values: Optional[list[T]]
     ) -> None:
         """Writes the specified collection of primitive values to the stream with an optional
         given key.
 
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values (Optional[List[T]]): The collection of primitive values to be written.
+            values (Optional[list[T]]): The collection of primitive values to be written.
         """
         pass
 
     @abstractmethod
     def write_collection_of_object_values(
-        self, key: Optional[str], values: Optional[List[U]]
+        self, key: Optional[str], values: Optional[list[U]]
     ) -> None:
         """Writes the specified collection of model objects to the stream with an optional
         given key.
 
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values (Optional[List[U]]): The collection of model objects to be written.
+            values (Optional[list[U]]): The collection of model objects to be written.
         """
         pass
 
     @abstractmethod
     def write_collection_of_enum_values(
-        self, key: Optional[str], values: Optional[List[K]]
+        self, key: Optional[str], values: Optional[list[K]]
     ) -> None:
         """Writes the specified collection of enum values to the stream with an optional given key.
 
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values Optional[List[K]): The enum values to be written.
+            values Optional[list[K]): The enum values to be written.
         """
         pass
 
@@ -165,7 +165,7 @@ class SerializationWriter(ABC):
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
             value (Parsable): The model object to be written.
-            additional_values_to_merge (List[Parsable]): The additional values to merge to the
+            additional_values_to_merge (list[Parsable]): The additional values to merge to the
             main value when serializing an intersection wrapper.
         """
         pass

--- a/packages/abstractions/kiota_abstractions/serialization/serialization_writer.py
+++ b/packages/abstractions/kiota_abstractions/serialization/serialization_writer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 from uuid import UUID
 
 from .parsable import Parsable
@@ -190,10 +190,10 @@ class SerializationWriter(ABC):
         pass
 
     @abstractmethod
-    def write_additional_data_value(self, value: Dict[str, Any]) -> None:
+    def write_additional_data_value(self, value: dict[str, Any]) -> None:
         """Writes the specified additional data to the stream.
         Args:
-            value (Dict[str, Any]): he additional data to be written.
+            value (dict[str, Any]): he additional data to be written.
         """
         pass
 

--- a/packages/abstractions/kiota_abstractions/serialization/serialization_writer_factory_registry.py
+++ b/packages/abstractions/kiota_abstractions/serialization/serialization_writer_factory_registry.py
@@ -1,5 +1,4 @@
 import re
-from typing import Dict
 
 from .serialization_writer import SerializationWriter
 from .serialization_writer_factory import SerializationWriterFactory
@@ -9,7 +8,7 @@ class SerializationWriterFactoryRegistry(SerializationWriterFactory):
     """This factory holds a list of all the registered factories for the various types of nodes.
     """
     # List of factories that are registered by content type.
-    CONTENT_TYPE_ASSOCIATED_FACTORIES: Dict[str, SerializationWriterFactory] = {}
+    CONTENT_TYPE_ASSOCIATED_FACTORIES: dict[str, SerializationWriterFactory] = {}
 
     __instance = None
 

--- a/packages/abstractions/kiota_abstractions/serialization/serialization_writer_proxy_factory.py
+++ b/packages/abstractions/kiota_abstractions/serialization/serialization_writer_proxy_factory.py
@@ -4,7 +4,8 @@
 # See License in the project root for license information.
 # ------------------------------------------------------------------------------
 
-from typing import Callable, Optional
+from collections.abc import Callable
+from typing import Optional
 
 from .parsable import Parsable
 from .serialization_writer import SerializationWriter

--- a/packages/abstractions/kiota_abstractions/store/backing_store.py
+++ b/packages/abstractions/kiota_abstractions/store/backing_store.py
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Generic, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Generic, Optional, Tuple, TypeVar
 
 T = TypeVar("T")
 
@@ -39,21 +39,21 @@ class BackingStore(ABC, Generic[T]):
         pass
 
     @abstractmethod
-    def enumerate_(self) -> List[Tuple[str, Any]]:
+    def enumerate_(self) -> list[Tuple[str, Any]]:
         """Enumerates all the values stored in the backing store. Values will be filtered if
         "ReturnOnlyChangedValues" is true.
 
         Returns:
-            List[Tuple[str, Any]]: The values available in the backing store.
+            list[Tuple[str, Any]]: The values available in the backing store.
         """
         pass
 
     @abstractmethod
-    def enumerate_keys_for_values_changed_to_null(self) -> List[str]:
+    def enumerate_keys_for_values_changed_to_null(self) -> list[str]:
         """Enumerates the keys for all values that changed to null.
 
         Returns:
-            List[str]: The keys for the values that changed to null.
+            list[str]: The keys for the values that changed to null.
         """
         pass
 

--- a/packages/abstractions/kiota_abstractions/store/backing_store.py
+++ b/packages/abstractions/kiota_abstractions/store/backing_store.py
@@ -5,7 +5,8 @@
 # ------------------------------------------------------------------------------
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Generic, Optional, Tuple, TypeVar
+from collections.abc import Callable
+from typing import Any, Generic, Optional, TypeVar
 
 T = TypeVar("T")
 
@@ -39,12 +40,12 @@ class BackingStore(ABC, Generic[T]):
         pass
 
     @abstractmethod
-    def enumerate_(self) -> list[Tuple[str, Any]]:
+    def enumerate_(self) -> list[tuple[str, Any]]:
         """Enumerates all the values stored in the backing store. Values will be filtered if
         "ReturnOnlyChangedValues" is true.
 
         Returns:
-            list[Tuple[str, Any]]: The values available in the backing store.
+            list[tuple[str, Any]]: The values available in the backing store.
         """
         pass
 

--- a/packages/abstractions/kiota_abstractions/store/backing_store_parse_node_factory.py
+++ b/packages/abstractions/kiota_abstractions/store/backing_store_parse_node_factory.py
@@ -4,9 +4,7 @@
 # See License in the project root for license information.
 # ------------------------------------------------------------------------------
 
-from typing import Callable
-
-from ..serialization import Parsable, ParseNodeFactory, ParseNodeProxyFactory
+from ..serialization import ParseNodeFactory, ParseNodeProxyFactory
 from .backed_model import BackedModel
 
 

--- a/packages/abstractions/kiota_abstractions/store/in_memory_backing_store.py
+++ b/packages/abstractions/kiota_abstractions/store/in_memory_backing_store.py
@@ -4,7 +4,7 @@
 # See License in the project root for license information.
 # ------------------------------------------------------------------------------
 
-from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Generic, List, Optional, Tuple, TypeVar
 from uuid import uuid4
 
 from .backed_model import BackedModel
@@ -18,8 +18,8 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
 
     def __init__(self) -> None:
 
-        self.__subscriptions: Dict[str, Callable[[str, Any, Any], None]] = {}
-        self.__store: Dict[str, Tuple[bool, Any]] = {}
+        self.__subscriptions: dict[str, Callable[[str, Any, Any], None]] = {}
+        self.__store: dict[str, Tuple[bool, Any]] = {}
         self.__initialization_completed: bool = False
         self.__return_only_changed_values: bool = False
 

--- a/packages/abstractions/kiota_abstractions/store/in_memory_backing_store.py
+++ b/packages/abstractions/kiota_abstractions/store/in_memory_backing_store.py
@@ -4,7 +4,7 @@
 # See License in the project root for license information.
 # ------------------------------------------------------------------------------
 
-from typing import Any, Callable, Generic, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Generic, Optional, Tuple, TypeVar
 from uuid import uuid4
 
 from .backed_model import BackedModel
@@ -112,12 +112,12 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
             self.__subscriptions[sub](key, old_value, value_to_add)
             # sub(key, old_value, value_to_add)
 
-    def enumerate_(self) -> List[Tuple[str, Any]]:
+    def enumerate_(self) -> list[Tuple[str, Any]]:
         """Enumerate the values in the store based on the ReturnOnlyChangedValues configuration
         value
 
         Returns:
-            List[Tuple[str, Any]]: A collection of changed values or the whole store based on the
+            list[Tuple[str, Any]]: A collection of changed values or the whole store based on the
             ReturnOnlyChangedValues configuration value.
         """
 
@@ -131,11 +131,11 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
             return [(key, val[1]) for key, val in keyval_pairs if val[0] is True]
         return [(key, val[1]) for key, val in keyval_pairs]
 
-    def enumerate_keys_for_values_changed_to_null(self) -> List[str]:
+    def enumerate_keys_for_values_changed_to_null(self) -> list[str]:
         """Enumerate the values in the store that have changed to None
 
         Returns:
-            List[str]: A collection of strings containing keys changed to None
+            list[str]: A collection of strings containing keys changed to None
         """
         return [key for key, val in self.__store.items() if val[0] and val[1] is None]
 

--- a/packages/abstractions/kiota_abstractions/store/in_memory_backing_store.py
+++ b/packages/abstractions/kiota_abstractions/store/in_memory_backing_store.py
@@ -4,7 +4,8 @@
 # See License in the project root for license information.
 # ------------------------------------------------------------------------------
 
-from typing import Any, Callable, Generic, Optional, Tuple, TypeVar
+from collections.abc import Callable
+from typing import Any, Generic, Optional, TypeVar
 from uuid import uuid4
 
 from .backed_model import BackedModel
@@ -19,7 +20,7 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
     def __init__(self) -> None:
 
         self.__subscriptions: dict[str, Callable[[str, Any, Any], None]] = {}
-        self.__store: dict[str, Tuple[bool, Any]] = {}
+        self.__store: dict[str, tuple[bool, Any]] = {}
         self.__initialization_completed: bool = False
         self.__return_only_changed_values: bool = False
 
@@ -112,12 +113,12 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
             self.__subscriptions[sub](key, old_value, value_to_add)
             # sub(key, old_value, value_to_add)
 
-    def enumerate_(self) -> list[Tuple[str, Any]]:
+    def enumerate_(self) -> list[tuple[str, Any]]:
         """Enumerate the values in the store based on the ReturnOnlyChangedValues configuration
         value
 
         Returns:
-            list[Tuple[str, Any]]: A collection of changed values or the whole store based on the
+            list[tuple[str, Any]]: A collection of changed values or the whole store based on the
             ReturnOnlyChangedValues configuration value.
         """
 

--- a/packages/abstractions/pyproject.toml
+++ b/packages/abstractions/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 keywords = ["kiota", "openAPI", "Microsoft", "Graph"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -24,7 +23,7 @@ documentation = "https://learn.microsoft.com/openapi/kiota/"
 packages = [{include = "kiota_abstractions"}]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 std-uritemplate = ">=2.0.0"
 opentelemetry-api = ">=1.27.0"
 opentelemetry-sdk = ">=1.27.0"

--- a/packages/abstractions/tests/conftest.py
+++ b/packages/abstractions/tests/conftest.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, Optional, Union
 from unittest.mock import Mock
 
 import pytest
@@ -56,11 +56,11 @@ class MockEntity(Parsable, AdditionalDataHolder, BackedModel):
     # The OdataType property
     odata_type: str = "#microsoft.graph.mockEntity"
     # The telephone numbers for the user. NOTE: Although this is a string collection, only one number can be set for this property. Read-only for users synced from on-premises directory. Returned by default. Supports $filter (eq, not, ge, le, startsWith).
-    business_phones: Optional[List[str]] = None
+    business_phones: Optional[list[str]] = None
     # The user or contact that is this user&apos;s manager. Read-only. (HTTP Methods: GET, PUT, DELETE.). Supports $expand.
     manager: Optional[MockEntity] = None
     # The user or contact that is this user& works with.
-    colleagues: Optional[List[MockEntity]] = None
+    colleagues: Optional[list[MockEntity]] = None
 
     @staticmethod
     def create_from_discriminator_value(parse_node: Optional[ParseNode] = None):
@@ -118,7 +118,7 @@ class TestEnum(Enum):
     
 @dataclass
 class QueryParams:
-    dataset: Union[TestEnum, List[TestEnum]]
+    dataset: Union[TestEnum, list[TestEnum]]
 
 @pytest.fixture
 def mock_user():

--- a/packages/abstractions/tests/conftest.py
+++ b/packages/abstractions/tests/conftest.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 from unittest.mock import Mock
 
 import pytest
@@ -34,7 +34,7 @@ class MockAccessTokenProvider(AccessTokenProvider):
         self.token = None
 
     async def get_authorization_token(
-        self, url: str, additional_authentication_context: Dict[str, Any] = {}
+        self, url: str, additional_authentication_context: dict[str, Any] = {}
     ) -> str:
         return "SomeToken"
 
@@ -45,7 +45,7 @@ class MockAccessTokenProvider(AccessTokenProvider):
 @dataclass
 class MockEntity(Parsable, AdditionalDataHolder, BackedModel):
     # Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
-    additional_data: Dict[str, Any] = field(default_factory=dict)
+    additional_data: dict[str, Any] = field(default_factory=dict)
     # Stores model information.
     backing_store: BackingStore = field(
         default_factory=BackingStoreFactorySingleton(backing_store_factory=None
@@ -74,12 +74,12 @@ class MockEntity(Parsable, AdditionalDataHolder, BackedModel):
             raise TypeError("parse_node cannot be null.")
         return MockEntity()
 
-    def get_field_deserializers(self, ) -> Dict[str, Callable[[ParseNode], None]]:
+    def get_field_deserializers(self, ) -> dict[str, Callable[[ParseNode], None]]:
         """
         The deserialization information for the current model
-        Returns: Dict[str, Callable[[ParseNode], None]]
+        Returns: dict[str, Callable[[ParseNode], None]]
         """
-        fields: Dict[str, Callable[[Any], None]] = {
+        fields: dict[str, Callable[[Any], None]] = {
             "@odata.type":
             lambda n: setattr(self, 'odata_type', n.get_str_value()),
             "id":

--- a/packages/abstractions/tests/conftest.py
+++ b/packages/abstractions/tests/conftest.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Optional, Union
+from collections.abc import Callable
+from typing import Any, Optional, Union
 from unittest.mock import Mock
 
 import pytest

--- a/packages/abstractions/tests/store/test_backing_store_factory_singleton.py
+++ b/packages/abstractions/tests/store/test_backing_store_factory_singleton.py
@@ -4,7 +4,7 @@
 # See License in the project root for license information.
 # ------------------------------------------------------------------------------
 
-from typing import Any, Callable, Generic, List, Tuple, TypeVar
+from typing import Any, Callable, Generic, Tuple, TypeVar
 
 import pytest
 
@@ -32,10 +32,10 @@ class MockTestBackingStore(BackingStore, Generic[T]):
     def clear(self) -> None:
         self.store.clear()
 
-    def enumerate_(self) -> List[Tuple[str, Any]]:
+    def enumerate_(self) -> list[Tuple[str, Any]]:
         return list(self.store.values())
 
-    def enumerate_keys_for_values_changed_to_null(self) -> List[str]:
+    def enumerate_keys_for_values_changed_to_null(self) -> list[str]:
         return list(k for k, v in self.store if v is None)
 
     def subscribe(

--- a/packages/abstractions/tests/store/test_backing_store_factory_singleton.py
+++ b/packages/abstractions/tests/store/test_backing_store_factory_singleton.py
@@ -4,8 +4,8 @@
 # See License in the project root for license information.
 # ------------------------------------------------------------------------------
 
-from typing import Any, Callable, Generic, Tuple, TypeVar
-
+from typing import Any, Generic, TypeVar
+from collections.abc import Callable
 import pytest
 
 from kiota_abstractions.store import BackingStoreFactorySingleton, InMemoryBackingStoreFactory
@@ -32,7 +32,7 @@ class MockTestBackingStore(BackingStore, Generic[T]):
     def clear(self) -> None:
         self.store.clear()
 
-    def enumerate_(self) -> list[Tuple[str, Any]]:
+    def enumerate_(self) -> list[tuple[str, Any]]:
         return list(self.store.values())
 
     def enumerate_keys_for_values_changed_to_null(self) -> list[str]:

--- a/packages/authentication/azure/kiota_authentication_azure/azure_identity_access_token_provider.py
+++ b/packages/authentication/azure/kiota_authentication_azure/azure_identity_access_token_provider.py
@@ -1,7 +1,7 @@
 import base64
 import inspect
 from pickle import TRUE
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 from urllib.parse import urlparse
 
 from kiota_abstractions.authentication import AccessTokenProvider, AllowedHostsValidator
@@ -33,8 +33,8 @@ class AzureIdentityAccessTokenProvider(AccessTokenProvider):
         self,
         credentials: Union["TokenCredential", "AsyncTokenCredential"],
         options: Optional[dict],
-        scopes: List[str] = [],
-        allowed_hosts: List[str] = [],
+        scopes: list[str] = [],
+        allowed_hosts: list[str] = [],
         is_cae_enabled: bool = True,
     ) -> None:
         if not credentials:

--- a/packages/authentication/azure/kiota_authentication_azure/azure_identity_access_token_provider.py
+++ b/packages/authentication/azure/kiota_authentication_azure/azure_identity_access_token_provider.py
@@ -28,6 +28,7 @@ class AzureIdentityAccessTokenProvider(AccessTokenProvider):
     CLAIMS_KEY = "claims"
     LOCALHOST_STRINGS = {"localhost", "[::1]", "::1", "127.0.0.1"}
 
+    # pylint: disable=too-many-positional-arguments
     def __init__(
         self,
         credentials: Union["TokenCredential", "AsyncTokenCredential"],

--- a/packages/authentication/azure/kiota_authentication_azure/azure_identity_access_token_provider.py
+++ b/packages/authentication/azure/kiota_authentication_azure/azure_identity_access_token_provider.py
@@ -1,7 +1,7 @@
 import base64
 import inspect
 from pickle import TRUE
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional, Union
 from urllib.parse import urlparse
 
 from kiota_abstractions.authentication import AccessTokenProvider, AllowedHostsValidator
@@ -32,7 +32,7 @@ class AzureIdentityAccessTokenProvider(AccessTokenProvider):
     def __init__(
         self,
         credentials: Union["TokenCredential", "AsyncTokenCredential"],
-        options: Optional[Dict],
+        options: Optional[dict],
         scopes: List[str] = [],
         allowed_hosts: List[str] = [],
         is_cae_enabled: bool = True,
@@ -54,7 +54,7 @@ class AzureIdentityAccessTokenProvider(AccessTokenProvider):
     async def get_authorization_token(
         self,
         uri: str,
-        additional_authentication_context: Dict[str, Any] = {},
+        additional_authentication_context: dict[str, Any] = {},
     ) -> str:
         """This method is called by the BaseBearerTokenAuthenticationProvider class to get the
         access token.

--- a/packages/authentication/azure/kiota_authentication_azure/azure_identity_authentication_provider.py
+++ b/packages/authentication/azure/kiota_authentication_azure/azure_identity_authentication_provider.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from kiota_abstractions.authentication import BaseBearerTokenAuthenticationProvider
 
@@ -16,8 +16,8 @@ class AzureIdentityAuthenticationProvider(BaseBearerTokenAuthenticationProvider)
         self,
         credentials: Union["TokenCredential", "AsyncTokenCredential"],
         options: Optional[dict] = None,
-        scopes: List[str] = [],
-        allowed_hosts: List[str] = [],
+        scopes: list[str] = [],
+        allowed_hosts: list[str] = [],
         is_cae_enabled: bool = True,
     ) -> None:
         """[summary]
@@ -26,7 +26,7 @@ class AzureIdentityAuthenticationProvider(BaseBearerTokenAuthenticationProvider)
             credentials (Union["TokenCredential", "AsyncTokenCredential"]): The
                 tokenCredential implementation to use for authentication.
             options (Optional[dict]): The options to use for authentication.
-            scopes (List[str], optional): The scopes to use for authentication.
+            scopes (list[str], optional): The scopes to use for authentication.
                 Defaults to an empty list.
             allowed_hosts (Set[str], optional): The allowed hosts to use for
                 authentication.

--- a/packages/authentication/azure/kiota_authentication_azure/azure_identity_authentication_provider.py
+++ b/packages/authentication/azure/kiota_authentication_azure/azure_identity_authentication_provider.py
@@ -28,7 +28,7 @@ class AzureIdentityAuthenticationProvider(BaseBearerTokenAuthenticationProvider)
             options (Optional[dict]): The options to use for authentication.
             scopes (list[str], optional): The scopes to use for authentication.
                 Defaults to an empty list.
-            allowed_hosts (Set[str], optional): The allowed hosts to use for
+            allowed_hosts (set[str], optional): The allowed hosts to use for
                 authentication.
         """
         super().__init__(

--- a/packages/authentication/azure/kiota_authentication_azure/azure_identity_authentication_provider.py
+++ b/packages/authentication/azure/kiota_authentication_azure/azure_identity_authentication_provider.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 class AzureIdentityAuthenticationProvider(BaseBearerTokenAuthenticationProvider):
 
+    # pylint: disable=too-many-positional-arguments
     def __init__(
         self,
         credentials: Union["TokenCredential", "AsyncTokenCredential"],

--- a/packages/authentication/azure/kiota_authentication_azure/azure_identity_authentication_provider.py
+++ b/packages/authentication/azure/kiota_authentication_azure/azure_identity_authentication_provider.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from kiota_abstractions.authentication import BaseBearerTokenAuthenticationProvider
 
@@ -15,7 +15,7 @@ class AzureIdentityAuthenticationProvider(BaseBearerTokenAuthenticationProvider)
     def __init__(
         self,
         credentials: Union["TokenCredential", "AsyncTokenCredential"],
-        options: Optional[Dict] = None,
+        options: Optional[dict] = None,
         scopes: List[str] = [],
         allowed_hosts: List[str] = [],
         is_cae_enabled: bool = True,

--- a/packages/authentication/azure/pyproject.toml
+++ b/packages/authentication/azure/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 keywords = ["kiota", "openAPI", "Microsoft", "Graph"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -24,7 +23,7 @@ documentation = "https://learn.microsoft.com/openapi/kiota/"
 packages = [{include = "kiota_authentication_azure"}]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 aiohttp = ">=3.8.0"
 azure-core = ">=1.21.1"
 microsoft-kiota-abstractions = {path="../../abstractions/", develop=true}

--- a/packages/bundle/kiota_bundle/default_request_adapter.py
+++ b/packages/bundle/kiota_bundle/default_request_adapter.py
@@ -29,7 +29,6 @@ from kiota_serialization_text.text_parse_node_factory import TextParseNodeFactor
 from kiota_serialization_text.text_serialization_writer_factory import (
     TextSerializationWriterFactory,
 )
-
 """
 The default client request adapter.
 """

--- a/packages/bundle/kiota_bundle/default_request_adapter.py
+++ b/packages/bundle/kiota_bundle/default_request_adapter.py
@@ -29,6 +29,7 @@ from kiota_serialization_text.text_parse_node_factory import TextParseNodeFactor
 from kiota_serialization_text.text_serialization_writer_factory import (
     TextSerializationWriterFactory,
 )
+
 """
 The default client request adapter.
 """

--- a/packages/bundle/pyproject.toml
+++ b/packages/bundle/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 keywords = ["kiota", "openAPI", "Microsoft", "Graph"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -25,7 +24,7 @@ documentation = "https://learn.microsoft.com/openapi/kiota/"
 packages = [{include = "kiota_bundle"}]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 microsoft-kiota-abstractions = {path="../../packages/abstractions/", develop=true}
 microsoft-kiota-http = {path="../../packages/http/httpx/", develop=true}
 microsoft-kiota-serialization-json = {path="../../packages/serialization/json/", develop=true}

--- a/packages/http/httpx/kiota_http/httpx_request_adapter.py
+++ b/packages/http/httpx/kiota_http/httpx_request_adapter.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import re
 from datetime import datetime
-from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
+from typing import Any, List, Optional, TypeVar, Union
 from urllib import parse
 
 from kiota_abstractions.api_client_builder import (
@@ -160,7 +160,7 @@ class HttpxRequestAdapter(RequestAdapter):
         self,
         request_info: RequestInformation,
         parsable_factory: ParsableFactory[ModelType],
-        error_map: Optional[Dict[str, type[ParsableFactory]]],
+        error_map: Optional[dict[str, type[ParsableFactory]]],
     ) -> Optional[ModelType]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
         deserialized response model.
@@ -168,7 +168,7 @@ class HttpxRequestAdapter(RequestAdapter):
             request_info (RequestInformation): the request info to execute.
             parsable_factory (ParsableFactory): the class of the response model
             to deserialize the response into.
-            error_map (Dict[str, type[ParsableFactory]]): the error dict to use in
+            error_map (dict[str, type[ParsableFactory]]): the error dict to use in
             case of a failed request.
 
         Returns:
@@ -205,7 +205,7 @@ class HttpxRequestAdapter(RequestAdapter):
         self,
         request_info: RequestInformation,
         parsable_factory: ParsableFactory,
-        error_map: Optional[Dict[str, type[ParsableFactory]]],
+        error_map: Optional[dict[str, type[ParsableFactory]]],
     ) -> Optional[List[ModelType]]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
         deserialized response model collection.
@@ -213,7 +213,7 @@ class HttpxRequestAdapter(RequestAdapter):
             request_info (RequestInformation): the request info to execute.
             parsable_factory (ParsableFactory): the class of the response model
             to deserialize the response into.
-            error_map (Dict[str, type[ParsableFactory]]): the error dict to use in
+            error_map (dict[str, type[ParsableFactory]]): the error dict to use in
             case of a failed request.
 
         Returns:
@@ -252,7 +252,7 @@ class HttpxRequestAdapter(RequestAdapter):
         self,
         request_info: RequestInformation,
         response_type: type[PrimitiveType],
-        error_map: Optional[Dict[str, type[ParsableFactory]]],
+        error_map: Optional[dict[str, type[ParsableFactory]]],
     ) -> Optional[List[PrimitiveType]]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
         deserialized response model collection.
@@ -260,7 +260,7 @@ class HttpxRequestAdapter(RequestAdapter):
             request_info (RequestInformation): the request info to execute.
             response_type (PrimitiveType): the class of the response model
             to deserialize the response into.
-            error_map (Dict[str, type[ParsableFactory]]): the error dict to use in
+            error_map (dict[str, type[ParsableFactory]]): the error dict to use in
             case of a failed request.
 
         Returns:
@@ -299,7 +299,7 @@ class HttpxRequestAdapter(RequestAdapter):
         self,
         request_info: RequestInformation,
         response_type: str,
-        error_map: Optional[Dict[str, type[ParsableFactory]]],
+        error_map: Optional[dict[str, type[ParsableFactory]]],
     ) -> Optional[ResponseType]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
         deserialized primitive response model.
@@ -307,7 +307,7 @@ class HttpxRequestAdapter(RequestAdapter):
             request_info (RequestInformation): the request info to execute.
             response_type (str): the class name of the response model to deserialize the
             response into.
-            error_map (Dict[str, type[ParsableFactory]]): the error dict to use in case
+            error_map (dict[str, type[ParsableFactory]]): the error dict to use in case
             of a failed request.
 
         Returns:
@@ -360,14 +360,14 @@ class HttpxRequestAdapter(RequestAdapter):
             parent_span.end()
 
     async def send_no_response_content_async(
-        self, request_info: RequestInformation, error_map: Optional[Dict[str,
+        self, request_info: RequestInformation, error_map: Optional[dict[str,
                                                                          type[ParsableFactory]]]
     ) -> None:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
         deserialized primitive response model.
         Args:
             request_info (RequestInformation):the request info to execute.
-            error_map (Dict[str, type[ParsableFactory]]): the error dict to use in case
+            error_map (dict[str, type[ParsableFactory]]): the error dict to use in case
             of a failed request.
         """
         parent_span = self.start_tracing_span(request_info, "send_no_response_content_async")
@@ -427,7 +427,7 @@ class HttpxRequestAdapter(RequestAdapter):
     async def throw_failed_responses(
         self,
         response: httpx.Response,
-        error_map: Optional[Dict[str, type[ParsableFactory]]],
+        error_map: Optional[dict[str, type[ParsableFactory]]],
         parent_span: trace.Span,
         attribute_span: trace.Span,
     ) -> None:
@@ -655,13 +655,13 @@ class HttpxRequestAdapter(RequestAdapter):
             parent_span.end()
 
     def _error_class_not_in_error_mapping(
-        self, error_map: Dict[str, type[ParsableFactory]], status_code: int
+        self, error_map: dict[str, type[ParsableFactory]], status_code: int
     ) -> bool:
         """Helper function to check if the error class corresponding to a response status code
         is not in the error mapping.
 
         Args:
-            error_map (Dict[str, type[ParsableFactory]]): The error mapping.
+            error_map (dict[str, type[ParsableFactory]]): The error mapping.
             status_code (int): The response status code.
 
         Returns:

--- a/packages/http/httpx/kiota_http/httpx_request_adapter.py
+++ b/packages/http/httpx/kiota_http/httpx_request_adapter.py
@@ -64,6 +64,7 @@ class HttpxRequestAdapter(RequestAdapter):
     BEARER_AUTHENTICATION_SCHEME = "Bearer"
     RESPONSE_AUTH_HEADER = "WWW-Authenticate"
 
+    # pylint: disable=too-many-positional-arguments
     def __init__(
         self,
         authentication_provider: AuthenticationProvider,

--- a/packages/http/httpx/kiota_http/httpx_request_adapter.py
+++ b/packages/http/httpx/kiota_http/httpx_request_adapter.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import re
 from datetime import datetime
-from typing import Any, List, Optional, TypeVar, Union
+from typing import Any, Optional, TypeVar, Union
 from urllib import parse
 
 from kiota_abstractions.api_client_builder import (
@@ -206,7 +206,7 @@ class HttpxRequestAdapter(RequestAdapter):
         request_info: RequestInformation,
         parsable_factory: ParsableFactory,
         error_map: Optional[dict[str, type[ParsableFactory]]],
-    ) -> Optional[List[ModelType]]:
+    ) -> Optional[list[ModelType]]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
         deserialized response model collection.
         Args:
@@ -239,7 +239,7 @@ class HttpxRequestAdapter(RequestAdapter):
             )
             root_node = await self.get_root_parse_node(response, parent_span, parent_span)
             if root_node:
-                result: Optional[List[ModelType]
+                result: Optional[list[ModelType]
                                  ] = root_node.get_collection_of_object_values(parsable_factory)
                 parent_span.set_attribute(DESERIALIZED_MODEL_NAME_KEY, result.__class__.__name__)
                 _deserialized_span.end()
@@ -253,7 +253,7 @@ class HttpxRequestAdapter(RequestAdapter):
         request_info: RequestInformation,
         response_type: type[PrimitiveType],
         error_map: Optional[dict[str, type[ParsableFactory]]],
-    ) -> Optional[List[PrimitiveType]]:
+    ) -> Optional[list[PrimitiveType]]:
         """Excutes the HTTP request specified by the given RequestInformation and returns the
         deserialized response model collection.
         Args:
@@ -264,7 +264,7 @@ class HttpxRequestAdapter(RequestAdapter):
             case of a failed request.
 
         Returns:
-            Optional[List[PrimitiveType]]: The deserialized primitive type collection.
+            Optional[list[PrimitiveType]]: The deserialized primitive type collection.
         """
         parent_span = self.start_tracing_span(request_info, "send_collection_of_primitive_async")
         try:

--- a/packages/http/httpx/kiota_http/httpx_request_adapter.py
+++ b/packages/http/httpx/kiota_http/httpx_request_adapter.py
@@ -1,5 +1,6 @@
 """HTTPX client request adapter."""
 from __future__ import annotations
+
 import re
 from datetime import datetime
 from typing import Any, Optional, TypeVar, Union
@@ -11,7 +12,7 @@ from kiota_abstractions.api_client_builder import (
 )
 from kiota_abstractions.api_error import APIError
 from kiota_abstractions.authentication import AuthenticationProvider
-from kiota_abstractions.request_adapter import RequestAdapter, ResponseType, PrimitiveType
+from kiota_abstractions.request_adapter import PrimitiveType, RequestAdapter, ResponseType
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.serialization import (
     Parsable,
@@ -25,12 +26,12 @@ from kiota_abstractions.serialization import (
 from kiota_abstractions.store import BackingStoreFactory, BackingStoreFactorySingleton
 from opentelemetry import trace
 from opentelemetry.semconv.attributes.http_attributes import (
-    HTTP_RESPONSE_STATUS_CODE,
     HTTP_REQUEST_METHOD,
+    HTTP_RESPONSE_STATUS_CODE,
 )
 from opentelemetry.semconv.attributes.network_attributes import NETWORK_PROTOCOL_NAME
 from opentelemetry.semconv.attributes.server_attributes import SERVER_ADDRESS
-from opentelemetry.semconv.attributes.url_attributes import URL_SCHEME, URL_FULL
+from opentelemetry.semconv.attributes.url_attributes import URL_FULL, URL_SCHEME
 
 import httpx
 from kiota_http._exceptions import (

--- a/packages/http/httpx/kiota_http/kiota_client_factory.py
+++ b/packages/http/httpx/kiota_http/kiota_client_factory.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Optional
 
 from kiota_abstractions.request_option import RequestOption
 
@@ -65,14 +65,14 @@ class KiotaClientFactory:
 
     @staticmethod
     def create_with_custom_middleware(
-        middleware: Optional[List[BaseMiddleware]],
+        middleware: Optional[list[BaseMiddleware]],
         client: Optional[httpx.AsyncClient] = None,
     ) -> httpx.AsyncClient:
         """Constructs native HTTP AsyncClient(httpx.AsyncClient) instances configured with
         a custom pipeline of middleware.
 
         Args:
-            middleware(List[BaseMiddleware]): Custom middleware list that will be used to create
+            middleware(list[BaseMiddleware]): Custom middleware list that will be used to create
             a middleware pipeline. The middleware should be arranged in the order in which they will
             modify the request.
         """
@@ -80,7 +80,7 @@ class KiotaClientFactory:
         return KiotaClientFactory._load_middleware_to_client(kiota_async_client, middleware)
 
     @staticmethod
-    def get_default_middleware(options: Optional[dict[str, RequestOption]]) -> List[BaseMiddleware]:
+    def get_default_middleware(options: Optional[dict[str, RequestOption]]) -> list[BaseMiddleware]:
         """
         Helper method that returns a list of default middleware instantiated with
         appropriate options
@@ -143,7 +143,7 @@ class KiotaClientFactory:
 
     @staticmethod
     def create_middleware_pipeline(
-        middleware: Optional[List[BaseMiddleware]], transport: httpx.AsyncBaseTransport
+        middleware: Optional[list[BaseMiddleware]], transport: httpx.AsyncBaseTransport
     ) -> MiddlewarePipeline:
         """
         Helper method that constructs a middleware_pipeline with the specified middleware
@@ -156,7 +156,7 @@ class KiotaClientFactory:
 
     @staticmethod
     def _load_middleware_to_client(
-        client: httpx.AsyncClient, middleware: Optional[List[BaseMiddleware]]
+        client: httpx.AsyncClient, middleware: Optional[list[BaseMiddleware]]
     ) -> httpx.AsyncClient:
         current_transport = client._transport
         client._transport = KiotaClientFactory._replace_transport_with_custom_kiota_transport(
@@ -177,7 +177,7 @@ class KiotaClientFactory:
 
     @staticmethod
     def _replace_transport_with_custom_kiota_transport(
-        current_transport: httpx.AsyncBaseTransport, middleware: Optional[List[BaseMiddleware]]
+        current_transport: httpx.AsyncBaseTransport, middleware: Optional[list[BaseMiddleware]]
     ) -> AsyncKiotaTransport:
         middleware_pipeline = KiotaClientFactory.create_middleware_pipeline(
             middleware, current_transport

--- a/packages/http/httpx/kiota_http/kiota_client_factory.py
+++ b/packages/http/httpx/kiota_http/kiota_client_factory.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from kiota_abstractions.request_option import RequestOption
 
@@ -45,14 +45,14 @@ class KiotaClientFactory:
     @staticmethod
     def create_with_default_middleware(
         client: Optional[httpx.AsyncClient] = None,
-        options: Optional[Dict[str, RequestOption]] = None
+        options: Optional[dict[str, RequestOption]] = None
     ) -> httpx.AsyncClient:
         """Constructs native HTTP AsyncClient(httpx.AsyncClient) instances configured with
         a custom transport loaded with a default pipeline of middleware.
 
         Args:
-            options (Optional[Dict[str, RequestOption]]): The request options to use when
-            instantiating default middleware. Defaults to Dict[str, RequestOption]=None.
+            options (Optional[dict[str, RequestOption]]): The request options to use when
+            instantiating default middleware. Defaults to dict[str, RequestOption]=None.
 
         Returns:
             httpx.AsycClient: An instance of the AsyncClient object
@@ -80,7 +80,7 @@ class KiotaClientFactory:
         return KiotaClientFactory._load_middleware_to_client(kiota_async_client, middleware)
 
     @staticmethod
-    def get_default_middleware(options: Optional[Dict[str, RequestOption]]) -> List[BaseMiddleware]:
+    def get_default_middleware(options: Optional[dict[str, RequestOption]]) -> List[BaseMiddleware]:
         """
         Helper method that returns a list of default middleware instantiated with
         appropriate options

--- a/packages/http/httpx/kiota_http/middleware/options/headers_inspection_handler_option.py
+++ b/packages/http/httpx/kiota_http/middleware/options/headers_inspection_handler_option.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License.
 # See License in the project root for license information.
 # ------------------------------------
-from typing import Dict
-
 from kiota_abstractions.headers_collection import HeadersCollection
 from kiota_abstractions.request_option import RequestOption
 

--- a/packages/http/httpx/kiota_http/middleware/options/parameters_name_decoding_handler_option.py
+++ b/packages/http/httpx/kiota_http/middleware/options/parameters_name_decoding_handler_option.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from kiota_abstractions.request_option import RequestOption
 
 
@@ -10,14 +8,14 @@ class ParametersNameDecodingHandlerOption(RequestOption):
     PARAMETERS_NAME_DECODING_HANDLER_OPTION_KEY = "ParametersNameDecodingHandlerOption"
 
     def __init__(
-        self, enable: bool = True, characters_to_decode: List[str] = [".", "-", "~", "$"]
+        self, enable: bool = True, characters_to_decode: list[str] = [".", "-", "~", "$"]
     ) -> None:
         """To create an instance of ParametersNameDecodingHandlerOptions
 
         Args:
             enable (bool, optional): - Whether to decode the specified characters in the
             request query parameters names. Defaults to True.
-            characters_to_decode (List[str], optional):- The characters to decode.
+            characters_to_decode (list[str], optional):- The characters to decode.
             Defaults to [".", "-", "~", "$"].
         """
         self._enable = enable
@@ -39,7 +37,7 @@ class ParametersNameDecodingHandlerOption(RequestOption):
         return self._characters_to_decode
 
     @characters_to_decode.setter
-    def characters_to_decode(self, value: List[str]):
+    def characters_to_decode(self, value: list[str]):
         self._characters_to_decode = value
 
     @staticmethod

--- a/packages/http/httpx/kiota_http/middleware/options/telemetry_handler_option.py
+++ b/packages/http/httpx/kiota_http/middleware/options/telemetry_handler_option.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 from kiota_abstractions.request_option import RequestOption
 

--- a/packages/http/httpx/kiota_http/middleware/options/url_replace_option.py
+++ b/packages/http/httpx/kiota_http/middleware/options/url_replace_option.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from kiota_abstractions.request_option import RequestOption
 
 
@@ -9,13 +7,13 @@ class UrlReplaceHandlerOption(RequestOption):
 
     URL_REPLACE_HANDLER_OPTION_KEY = "UrlReplaceHandlerOption"
 
-    def __init__(self, enabled: bool = True, replacement_pairs: Dict[str, str] = {}) -> None:
+    def __init__(self, enabled: bool = True, replacement_pairs: dict[str, str] = {}) -> None:
         """Creates an instance of url replace option.
 
         Args:
             enabled (bool, optional): Whether to enable the url replace handler.
             Defaults to True.
-            replacement_pairs (Dict[str, str], optional): Dictionary of values
+            replacement_pairs (dict[str, str], optional): dictionary of values
             to replace. Defaults to {}.
         """
         self._enabled = enabled
@@ -36,7 +34,7 @@ class UrlReplaceHandlerOption(RequestOption):
         return self._replacement_pairs
 
     @replacement_pairs.setter
-    def replacement_pairs(self, value: Dict[str, str]):
+    def replacement_pairs(self, value: dict[str, str]):
         self._replacement_pairs = value
 
     @staticmethod

--- a/packages/http/httpx/kiota_http/middleware/parameters_name_decoding_handler.py
+++ b/packages/http/httpx/kiota_http/middleware/parameters_name_decoding_handler.py
@@ -1,6 +1,3 @@
-from typing import List
-from urllib.parse import urlparse
-
 from kiota_abstractions.request_option import RequestOption
 
 import httpx
@@ -81,7 +78,7 @@ class ParametersNameDecodingHandler(BaseMiddleware):
             return current_options
         return self.options
 
-    def decode_uri_encoded_string(self, original: str, characters_to_decode: List[str]) -> str:
+    def decode_uri_encoded_string(self, original: str, characters_to_decode: list[str]) -> str:
         """Decodes a uri encoded url string"""
         if not original or not characters_to_decode:
             return original

--- a/packages/http/httpx/kiota_http/middleware/redirect_handler.py
+++ b/packages/http/httpx/kiota_http/middleware/redirect_handler.py
@@ -71,7 +71,7 @@ class RedirectHandler(BaseMiddleware):
         _enable_span.end()
 
         max_redirect = current_options.max_redirect
-        history: typing.List[httpx.Request] = []
+        history: list[httpx.Request] = []
 
         while max_redirect >= 0:
             _redirect_span = self._create_observability_span(

--- a/packages/http/httpx/kiota_http/middleware/redirect_handler.py
+++ b/packages/http/httpx/kiota_http/middleware/redirect_handler.py
@@ -1,9 +1,7 @@
 import typing
 
 from kiota_abstractions.request_option import RequestOption
-from opentelemetry.semconv.attributes.http_attributes import (
-    HTTP_RESPONSE_STATUS_CODE,
-)
+from opentelemetry.semconv.attributes.http_attributes import HTTP_RESPONSE_STATUS_CODE
 
 import httpx
 
@@ -19,7 +17,7 @@ class RedirectHandler(BaseMiddleware):
     """Middlware that allows us to define the redirect policy for all requests
     """
 
-    DEFAULT_REDIRECT_STATUS_CODES: typing.Set[int] = {
+    DEFAULT_REDIRECT_STATUS_CODES: set[int] = {
         301,  # Moved Permanently
         302,  # Found
         303,  # See Other
@@ -33,7 +31,7 @@ class RedirectHandler(BaseMiddleware):
     def __init__(self, options: RedirectHandlerOption = RedirectHandlerOption()) -> None:
         super().__init__()
         self.options = options
-        self.redirect_on_status_codes: typing.Set[int] = self.DEFAULT_REDIRECT_STATUS_CODES
+        self.redirect_on_status_codes: set[int] = self.DEFAULT_REDIRECT_STATUS_CODES
 
     def increment(self, response, max_redirect, history) -> bool:
         """Increment the redirect attempts for this request.

--- a/packages/http/httpx/kiota_http/middleware/retry_handler.py
+++ b/packages/http/httpx/kiota_http/middleware/retry_handler.py
@@ -2,12 +2,9 @@ import datetime
 import random
 import time
 from email.utils import parsedate_to_datetime
-from typing import FrozenSet, Set, Type
 
 from kiota_abstractions.request_option import RequestOption
-from opentelemetry.semconv.attributes.http_attributes import (
-    HTTP_RESPONSE_STATUS_CODE,
-)
+from opentelemetry.semconv.attributes.http_attributes import HTTP_RESPONSE_STATUS_CODE
 
 import httpx
 
@@ -53,20 +50,20 @@ class RetryHandler(BaseMiddleware):
     # 429 - Too many requests
     # 503 - Service unavailable
     # 504 - Gateway timeout
-    DEFAULT_RETRY_STATUS_CODES: Set[int] = {429, 503, 504}
+    DEFAULT_RETRY_STATUS_CODES: set[int] = {429, 503, 504}
 
-    DEFAULT_ALLOWED_METHODS: FrozenSet[str] = frozenset(
+    DEFAULT_ALLOWED_METHODS: frozenset[str] = frozenset(
         ['HEAD', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']
     )
 
     def __init__(self, options: RetryHandlerOption = RetryHandlerOption()) -> None:
         super().__init__()
-        self.allowed_methods: FrozenSet[str] = self.DEFAULT_ALLOWED_METHODS
+        self.allowed_methods: frozenset[str] = self.DEFAULT_ALLOWED_METHODS
         self.backoff_factor: float = self.DEFAULT_BACKOFF_FACTOR
         self.backoff_max: int = self.MAXIMUM_BACKOFF
         self.options = options
         self.respect_retry_after_header: bool = self.options.DEFAULT_SHOULD_RETRY  # type:ignore
-        self.retry_on_status_codes: Set[int] = self.DEFAULT_RETRY_STATUS_CODES
+        self.retry_on_status_codes: set[int] = self.DEFAULT_RETRY_STATUS_CODES
 
     async def send(self, request: httpx.Request, transport: httpx.AsyncBaseTransport):
         """

--- a/packages/http/httpx/kiota_http/middleware/url_replace_handler.py
+++ b/packages/http/httpx/kiota_http/middleware/url_replace_handler.py
@@ -1,5 +1,5 @@
 from kiota_abstractions.request_option import RequestOption
-from opentelemetry.semconv.attributes.url_attributes import (URL_FULL)
+from opentelemetry.semconv.attributes.url_attributes import URL_FULL
 
 import httpx
 

--- a/packages/http/httpx/pyproject.toml
+++ b/packages/http/httpx/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 keywords = ["kiota", "openAPI", "Microsoft", "Graph"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -25,7 +24,7 @@ documentation = "https://learn.microsoft.com/openapi/kiota/"
 packages = [{include = "kiota_http"}]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 microsoft-kiota-abstractions = {path="../../abstractions/", develop=true}
 opentelemetry-api = ">=1.27.0"
 opentelemetry-sdk = ">=1.27.0"

--- a/packages/http/httpx/tests/helpers/mock_response_object.py
+++ b/packages/http/httpx/tests/helpers/mock_response_object.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 
 from kiota_abstractions.serialization import (
     AdditionalDataHolder,
@@ -29,7 +29,7 @@ class MockResponseObject(Parsable, AdditionalDataHolder):
         self._is_active: Optional[bool] = None
         self._age: Optional[int] = None
         self._gpa: Optional[float] = None
-        self._additional_data: Dict[str, Any] = {}
+        self._additional_data: dict[str, Any] = {}
 
     @property
     def id(self):
@@ -112,11 +112,11 @@ class MockResponseObject(Parsable, AdditionalDataHolder):
         self._gpa = new_gpa
 
     @property
-    def additional_data(self) -> Dict[str, Any]:
+    def additional_data(self) -> dict[str, Any]:
         return self._additional_data
 
     @additional_data.setter
-    def additional_data(self, data: Dict[str, Any]) -> None:
+    def additional_data(self, data: dict[str, Any]) -> None:
         self._additional_data = data
 
     def get_object_value(self, model_class):
@@ -145,11 +145,11 @@ class MockResponseObject(Parsable, AdditionalDataHolder):
             raise Exception("parse_node cannot be undefined")
         return MockResponseObject()
 
-    def get_field_deserializers(self) -> Optional[Dict[str, Callable[[ParseNode], None]]]:
+    def get_field_deserializers(self) -> Optional[dict[str, Callable[[ParseNode], None]]]:
         """Gets the deserialization information for this object.
 
         Returns:
-            Dict[str, Callable[[ParseNode], None]]: The deserialization information for this
+            dict[str, Callable[[ParseNode], None]]: The deserialization information for this
             object where each entry is a property key with its deserialization callback.
         """
         pass

--- a/packages/http/httpx/tests/helpers/mock_response_object.py
+++ b/packages/http/httpx/tests/helpers/mock_response_object.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import Any, Callable, Optional, TypeVar
+from collections.abc import Callable
+from typing import Any, Optional, TypeVar
 
 from kiota_abstractions.serialization import (
     AdditionalDataHolder,

--- a/packages/http/httpx/tests/helpers/mock_response_object.py
+++ b/packages/http/httpx/tests/helpers/mock_response_object.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
 from kiota_abstractions.serialization import (
     AdditionalDataHolder,
@@ -24,7 +24,7 @@ class MockResponseObject(Parsable, AdditionalDataHolder):
         self._office_location: Optional[OfficeLocation] = None
         self._updated_at: Optional[datetime] = None
         self._birthday: Optional[date] = None
-        self._business_phones: Optional[List[str]] = None
+        self._business_phones: Optional[list[str]] = None
         self._mobile_phone: Optional[str] = None
         self._is_active: Optional[bool] = None
         self._age: Optional[int] = None

--- a/packages/serialization/form/kiota_serialization_form/form_parse_node.py
+++ b/packages/serialization/form/kiota_serialization_form/form_parse_node.py
@@ -4,7 +4,7 @@ import warnings
 from collections import defaultdict
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 from urllib.parse import unquote_plus
 from uuid import UUID
 
@@ -333,7 +333,7 @@ class FormParseNode(ParseNode):
         new_node.on_after_assign_field_values = self.on_after_assign_field_values
         return new_node
 
-    def _get_fields(self, raw_value: str) -> Dict[str, str]:
+    def _get_fields(self, raw_value: str) -> dict[str, str]:
         fields = raw_value.split('&')
         field_values = defaultdict(list)
         for field in fields:
@@ -344,7 +344,7 @@ class FormParseNode(ParseNode):
                 field_values[key].append(value)
 
         # Convert lists to comma-separated strings
-        result: Dict[str, str] = {}
+        result: dict[str, str] = {}
         for key in field_values:
             result[key] = ','.join(field_values[key])
         return result

--- a/packages/serialization/form/kiota_serialization_form/form_parse_node.py
+++ b/packages/serialization/form/kiota_serialization_form/form_parse_node.py
@@ -4,7 +4,7 @@ import warnings
 from collections import defaultdict
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 from urllib.parse import unquote_plus
 from uuid import UUID
 
@@ -167,12 +167,12 @@ class FormParseNode(ParseNode):
             return FormParseNode(self._fields[field_name])
         return None
 
-    def get_collection_of_primitive_values(self, primitive_type: type[T]) -> Optional[List[T]]:
+    def get_collection_of_primitive_values(self, primitive_type: type[T]) -> Optional[list[T]]:
         """Gets the collection of primitive values of the node
         Args:
             primitive_type: The type of primitive to return.
         Returns:
-            List[T]: The collection of primitive values
+            list[T]: The collection of primitive values
         """
         if not primitive_type:
             raise Exception("Primitive type for deserialization cannot be null")
@@ -180,7 +180,7 @@ class FormParseNode(ParseNode):
         primitive_types = {bool, str, int, float, UUID, datetime, timedelta, date, time, bytes}
         if primitive_type in primitive_types:
             items = self._node.split(',')
-            result: List[T] = []
+            result: list[T] = []
             for item in items:
                 current_parse_node = self._create_new_node(item)
                 method_name = f"get_{primitive_type.__name__.lower()}_value"
@@ -189,13 +189,13 @@ class FormParseNode(ParseNode):
             return result
         raise Exception(f"Encountered an unknown type during deserialization {primitive_type}")
 
-    def get_collection_of_object_values(self, factory: ParsableFactory[U]) -> Optional[List[U]]:
+    def get_collection_of_object_values(self, factory: ParsableFactory[U]) -> Optional[list[U]]:
         raise Exception("Collection of object values is not supported with uri form encoding.")
 
-    def get_collection_of_enum_values(self, enum_class: K) -> Optional[List[K]]:
+    def get_collection_of_enum_values(self, enum_class: K) -> Optional[list[K]]:
         """Gets the collection of enum values of the node
         Returns:
-            List[K]: The collection of enum values
+            list[K]: The collection of enum values
         """
         values = self._node.split(',')
         if values:

--- a/packages/serialization/form/kiota_serialization_form/form_parse_node.py
+++ b/packages/serialization/form/kiota_serialization_form/form_parse_node.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import warnings
 from collections import defaultdict
+from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Optional, TypeVar
 from urllib.parse import unquote_plus
 from uuid import UUID
 

--- a/packages/serialization/form/kiota_serialization_form/form_serialization_writer.py
+++ b/packages/serialization/form/kiota_serialization_form/form_serialization_writer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 from urllib.parse import quote_plus
 from uuid import UUID
 
@@ -124,13 +124,13 @@ class FormSerializationWriter(SerializationWriter):
             self.write_str_value(key, base64_string)
 
     def write_collection_of_primitive_values(
-        self, key: Optional[str], values: Optional[List[T]]
+        self, key: Optional[str], values: Optional[list[T]]
     ) -> None:
         """Writes the specified collection of primitive values to the stream with an optional
         given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values (Optional[List[T]]): The collection of primitive values to be written.
+            values (Optional[list[T]]): The collection of primitive values to be written.
         """
         primitive_types = [bool, str, int, float, UUID, datetime, timedelta, date, time, Enum]
         if key and values:
@@ -140,12 +140,12 @@ class FormSerializationWriter(SerializationWriter):
                     method(key, val)
 
     def write_collection_of_enum_values(
-        self, key: Optional[str], values: Optional[List[K]]
+        self, key: Optional[str], values: Optional[list[K]]
     ) -> None:
         """Writes the specified collection of enum values to the stream with an optional given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values Optional[List[K]): The enum values to be written.
+            values Optional[list[K]): The enum values to be written.
         """
         if key and values:
             if isinstance(values, list):
@@ -167,13 +167,13 @@ class FormSerializationWriter(SerializationWriter):
                 self.write_str_value(key, values)
 
     def write_collection_of_object_values(
-        self, key: Optional[str], values: Optional[List[U]]
+        self, key: Optional[str], values: Optional[list[U]]
     ) -> None:
         """Writes the specified collection of model objects to the stream with an optional
         given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values (Optional[List[U]]): The collection of model objects to be written.
+            values (Optional[list[U]]): The collection of model objects to be written.
         """
         raise Exception("Form serialization does not support collections.")
 

--- a/packages/serialization/form/kiota_serialization_form/form_serialization_writer.py
+++ b/packages/serialization/form/kiota_serialization_form/form_serialization_writer.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import base64
+from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Optional, TypeVar
 from urllib.parse import quote_plus
 from uuid import UUID
 

--- a/packages/serialization/form/kiota_serialization_form/form_serialization_writer.py
+++ b/packages/serialization/form/kiota_serialization_form/form_serialization_writer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 from urllib.parse import quote_plus
 from uuid import UUID
 
@@ -217,10 +217,10 @@ class FormSerializationWriter(SerializationWriter):
         if key:
             self.write_str_value(key, "null")
 
-    def write_additional_data_value(self, value: Dict[str, Any]) -> None:
+    def write_additional_data_value(self, value: dict[str, Any]) -> None:
         """Writes the specified additional data to the stream.
         Args:
-            value (Dict[str, Any]): he additional data to be written.
+            value (dict[str, Any]): he additional data to be written.
         """
         if isinstance(value, dict):
             for key, val in value.items():

--- a/packages/serialization/form/pyproject.toml
+++ b/packages/serialization/form/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 keywords = ["kiota", "openAPI", "Microsoft", "Graph"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -24,7 +23,7 @@ documentation = "https://learn.microsoft.com/openapi/kiota/"
 packages = [{include = "kiota_serialization_form"}]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 microsoft-kiota-abstractions = {path="../../abstractions/", develop=true}
 pendulum = ">=3.0.0b1"
 

--- a/packages/serialization/form/tests/helpers/test_entity.py
+++ b/packages/serialization/form/tests/helpers/test_entity.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, time
-from typing import Any, Callable, Optional, TypeVar
+from collections.abc import Callable
+from typing import Any, Optional, TypeVar
 from uuid import UUID
 
 from kiota_abstractions.serialization import (

--- a/packages/serialization/form/tests/helpers/test_entity.py
+++ b/packages/serialization/form/tests/helpers/test_entity.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, time
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 from uuid import UUID
 
 from kiota_abstractions.serialization import (
@@ -20,7 +20,7 @@ T = TypeVar('T')
 class TestEntity(Parsable, AdditionalDataHolder):
     additional_data: dict[str, Any] = field(default_factory=dict)
     id: Optional[UUID] = None
-    device_names: Optional[List[str]] = None
+    device_names: Optional[list[str]] = None
     numbers: Optional[TestEnum] = None
     work_duration: Optional[timedelta] = None
     birthday: Optional[date] = None

--- a/packages/serialization/form/tests/helpers/test_entity.py
+++ b/packages/serialization/form/tests/helpers/test_entity.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, time
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 from uuid import UUID
 
 from kiota_abstractions.serialization import (
@@ -18,7 +18,7 @@ T = TypeVar('T')
 
 @dataclass
 class TestEntity(Parsable, AdditionalDataHolder):
-    additional_data: Dict[str, Any] = field(default_factory=dict)
+    additional_data: dict[str, Any] = field(default_factory=dict)
     id: Optional[UUID] = None
     device_names: Optional[List[str]] = None
     numbers: Optional[TestEnum] = None
@@ -41,11 +41,11 @@ class TestEntity(Parsable, AdditionalDataHolder):
             raise TypeError("parse_node cannot be null")
         return TestEntity()
 
-    def get_field_deserializers(self) -> Dict[str, Callable[[ParseNode], None]]:
+    def get_field_deserializers(self) -> dict[str, Callable[[ParseNode], None]]:
         """Gets the deserialization information for this object.
 
         Returns:
-            Dict[str, Callable[[ParseNode], None]]: The deserialization information for this
+            dict[str, Callable[[ParseNode], None]]: The deserialization information for this
             object where each entry is a property key with its deserialization callback.
         """
         return {

--- a/packages/serialization/json/kiota_serialization_json/json_parse_node.py
+++ b/packages/serialization/json/kiota_serialization_json/json_parse_node.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import json
 import re
 import warnings
+from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Optional, TypeVar
 from uuid import UUID
 
 import pendulum

--- a/packages/serialization/json/kiota_serialization_json/json_parse_node.py
+++ b/packages/serialization/json/kiota_serialization_json/json_parse_node.py
@@ -5,7 +5,7 @@ import re
 import warnings
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 from uuid import UUID
 
 import pendulum
@@ -139,12 +139,12 @@ class JsonParseNode(ParseNode):
                 return datetime_obj
         return None
 
-    def get_collection_of_primitive_values(self, primitive_type: type[T]) -> Optional[List[T]]:
+    def get_collection_of_primitive_values(self, primitive_type: type[T]) -> Optional[list[T]]:
         """Gets the collection of primitive values of the node
         Args:
             primitive_type: The type of primitive to return.
         Returns:
-            List[T]: The collection of primitive values
+            list[T]: The collection of primitive values
         """
 
         primitive_types = {bool, str, int, float, UUID, datetime, timedelta, date, time, bytes}
@@ -161,10 +161,10 @@ class JsonParseNode(ParseNode):
             return list(map(func, json.loads(self._json_node)))
         return list(map(func, list(self._json_node)))
 
-    def get_collection_of_object_values(self, factory: ParsableFactory[U]) -> Optional[List[U]]:
+    def get_collection_of_object_values(self, factory: ParsableFactory[U]) -> Optional[list[U]]:
         """Gets the collection of type U values from the json node
         Returns:
-            List[U]: The collection of model object values of the node
+            list[U]: The collection of model object values of the node
         """
         if isinstance(self._json_node, list):
             return list(
@@ -175,10 +175,10 @@ class JsonParseNode(ParseNode):
             )
         return []
 
-    def get_collection_of_enum_values(self, enum_class: K) -> Optional[List[K]]:
+    def get_collection_of_enum_values(self, enum_class: K) -> Optional[list[K]]:
         """Gets the collection of enum values of the json node
         Returns:
-            List[K]: The collection of enum values
+            list[K]: The collection of enum values
         """
         if isinstance(self._json_node, list):
             return list(

--- a/packages/serialization/json/kiota_serialization_json/json_serialization_writer.py
+++ b/packages/serialization/json/kiota_serialization_json/json_serialization_writer.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import base64
 import json
+from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Optional, TypeVar
 from uuid import UUID
 
 import pendulum

--- a/packages/serialization/json/kiota_serialization_json/json_serialization_writer.py
+++ b/packages/serialization/json/kiota_serialization_json/json_serialization_writer.py
@@ -4,7 +4,7 @@ import base64
 import json
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 from uuid import UUID
 
 import pendulum
@@ -22,7 +22,7 @@ class JsonSerializationWriter(SerializationWriter):
     PROPERTY_SEPARATOR: str = ','
 
     def __init__(self) -> None:
-        self.writer: Dict = {}
+        self.writer: dict = {}
         self.value: Any = None
 
         self._on_start_object_serialization: Optional[Callable[[Parsable, SerializationWriter],
@@ -256,13 +256,13 @@ class JsonSerializationWriter(SerializationWriter):
                 self.value = result
 
     def __write_collection_of_dict_values(
-        self, key: Optional[str], values: Optional[List[Dict[str, Any]]]
+        self, key: Optional[str], values: Optional[List[dict[str, Any]]]
     ) -> None:
         """Writes the specified collection of dictionary values to the stream with an optional
             given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values (Optional[List[Dict[str, Any]]]): The collection of dictionary values
+            values (Optional[List[dict[str, Any]]]): The collection of dictionary values
             to be written.
         """
         if isinstance(values, list):
@@ -344,11 +344,11 @@ class JsonSerializationWriter(SerializationWriter):
         else:
             self.value = None
 
-    def __write_dict_value(self, key: Optional[str], value: Dict[str, Any]) -> None:
+    def __write_dict_value(self, key: Optional[str], value: dict[str, Any]) -> None:
         """Writes the specified dictionary value to the stream with an optional given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            value (Dict[str, Any]): The dictionary value to be written.
+            value (dict[str, Any]): The dictionary value to be written.
         """
         if isinstance(value, dict):
             temp_writer: JsonSerializationWriter = self._create_new_writer()
@@ -359,10 +359,10 @@ class JsonSerializationWriter(SerializationWriter):
             else:
                 self.value = temp_writer.writer
 
-    def write_additional_data_value(self, value: Dict[str, Any]) -> None:
+    def write_additional_data_value(self, value: dict[str, Any]) -> None:
         """Writes the specified additional data to the stream.
         Args:
-            value (Dict[str, Any]): The additional data to be written.
+            value (dict[str, Any]): The additional data to be written.
         """
         if isinstance(value, dict):
             for key, val in value.items():

--- a/packages/serialization/json/kiota_serialization_json/json_serialization_writer.py
+++ b/packages/serialization/json/kiota_serialization_json/json_serialization_writer.py
@@ -4,7 +4,7 @@ import base64
 import json
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 from uuid import UUID
 
 import pendulum
@@ -194,13 +194,13 @@ class JsonSerializationWriter(SerializationWriter):
                 raise ValueError("Invalid time string value found")
 
     def write_collection_of_primitive_values(
-        self, key: Optional[str], values: Optional[List[T]]
+        self, key: Optional[str], values: Optional[list[T]]
     ) -> None:
         """Writes the specified collection of primitive values to the stream with an optional
         given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values (Optional[List[T]]): The collection of primitive values to be written.
+            values (Optional[list[T]]): The collection of primitive values to be written.
         """
         if isinstance(values, list):
             result = []
@@ -215,13 +215,13 @@ class JsonSerializationWriter(SerializationWriter):
                 self.value = result
 
     def write_collection_of_object_values(
-        self, key: Optional[str], values: Optional[List[U]]
+        self, key: Optional[str], values: Optional[list[U]]
     ) -> None:
         """Writes the specified collection of model objects to the stream with an optional
         given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values (Optional[List[U]]): The collection of model objects to be written.
+            values (Optional[list[U]]): The collection of model objects to be written.
         """
         if isinstance(values, list):
             obj_list = []
@@ -236,12 +236,12 @@ class JsonSerializationWriter(SerializationWriter):
                 self.value = obj_list
 
     def write_collection_of_enum_values(
-        self, key: Optional[str], values: Optional[List[K]]
+        self, key: Optional[str], values: Optional[list[K]]
     ) -> None:
         """Writes the specified collection of enum values to the stream with an optional given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values (Optional[List[K]]): The enum values to be written.
+            values (Optional[list[K]]): The enum values to be written.
         """
         if isinstance(values, list):
             result = []
@@ -256,13 +256,13 @@ class JsonSerializationWriter(SerializationWriter):
                 self.value = result
 
     def __write_collection_of_dict_values(
-        self, key: Optional[str], values: Optional[List[dict[str, Any]]]
+        self, key: Optional[str], values: Optional[list[dict[str, Any]]]
     ) -> None:
         """Writes the specified collection of dictionary values to the stream with an optional
             given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values (Optional[List[dict[str, Any]]]): The collection of dictionary values
+            values (Optional[list[dict[str, Any]]]): The collection of dictionary values
             to be written.
         """
         if isinstance(values, list):

--- a/packages/serialization/json/pyproject.toml
+++ b/packages/serialization/json/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 keywords = ["kiota", "openAPI", "Microsoft", "Graph"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -24,7 +23,7 @@ documentation = "https://learn.microsoft.com/openapi/kiota/"
 packages = [{include = "kiota_serialization_json"}]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 microsoft-kiota-abstractions = {path="../../abstractions/", develop=true}
 pendulum = ">=3.0.0b1"
 

--- a/packages/serialization/json/tests/helpers/entity.py
+++ b/packages/serialization/json/tests/helpers/entity.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Optional
+from collections.abc import Callable
+from typing import Optional
 from uuid import UUID
 
 from kiota_abstractions.serialization import Parsable, ParseNode, SerializationWriter

--- a/packages/serialization/json/tests/helpers/entity.py
+++ b/packages/serialization/json/tests/helpers/entity.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Dict, Optional
+from typing import Callable, Optional
 from uuid import UUID
 
 from kiota_abstractions.serialization import Parsable, ParseNode, SerializationWriter
@@ -24,11 +24,11 @@ class Entity(Parsable):
             raise ValueError("parse_node cannot be undefined")
         return Entity()
 
-    def get_field_deserializers(self) -> Dict[str, Callable[[ParseNode], None]]:
+    def get_field_deserializers(self) -> dict[str, Callable[[ParseNode], None]]:
         """Gets the deserialization information for this object.
 
         Returns:
-            Dict[str, Callable[[ParseNode], None]]: The deserialization information for this
+            dict[str, Callable[[ParseNode], None]]: The deserialization information for this
             object where each entry is a property key with its deserialization callback.
         """
         return {

--- a/packages/serialization/json/tests/helpers/intersection_type.py
+++ b/packages/serialization/json/tests/helpers/intersection_type.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any, Optional
 
 from kiota_abstractions.serialization import (
     AdditionalDataHolder,

--- a/packages/serialization/json/tests/helpers/intersection_type.py
+++ b/packages/serialization/json/tests/helpers/intersection_type.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Optional
 
 from kiota_abstractions.serialization import (
     AdditionalDataHolder,
@@ -20,7 +20,7 @@ class InterSectionType(AdditionalDataHolder, Parsable):
     composed_type1: Optional[User] = None
     composed_type2: Optional[User2] = None
     string_value: Optional[str] = None
-    composed_type3: Optional[List[User]] = None
+    composed_type3: Optional[list[User]] = None
 
     @staticmethod
     def create_from_discriminator_value(parse_node: Optional[ParseNode] = None) -> InterSectionType:

--- a/packages/serialization/json/tests/helpers/intersection_type.py
+++ b/packages/serialization/json/tests/helpers/intersection_type.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, List, Optional
 
 from kiota_abstractions.serialization import (
     AdditionalDataHolder,
@@ -16,7 +16,7 @@ from . import User, User2
 
 @dataclass
 class InterSectionType(AdditionalDataHolder, Parsable):
-    additional_data: Dict[str, Any] = field(default_factory=dict)
+    additional_data: dict[str, Any] = field(default_factory=dict)
     composed_type1: Optional[User] = None
     composed_type2: Optional[User2] = None
     string_value: Optional[str] = None
@@ -44,11 +44,11 @@ class InterSectionType(AdditionalDataHolder, Parsable):
 
         return result
 
-    def get_field_deserializers(self) -> Dict[str, Callable[[ParseNode], None]]:
+    def get_field_deserializers(self) -> dict[str, Callable[[ParseNode], None]]:
         """Gets the deserialization information for this object.
 
         Returns:
-            Dict[str, Callable[[ParseNode], None]]: The deserialization information for this
+            dict[str, Callable[[ParseNode], None]]: The deserialization information for this
             object where each entry is a property key with its deserialization callback.
         """
         if self.composed_type1 or self.composed_type2:

--- a/packages/serialization/json/tests/helpers/union_type.py
+++ b/packages/serialization/json/tests/helpers/union_type.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, List, Optional
 
 from kiota_abstractions.serialization import Parsable, ParseNode, SerializationWriter
 
@@ -10,7 +10,7 @@ from . import User, User2
 
 @dataclass
 class UnionType(Parsable):
-    additional_data: Dict[str, Any] = field(default_factory=dict)
+    additional_data: dict[str, Any] = field(default_factory=dict)
     composed_type1: Optional[User] = None
     composed_type2: Optional[User2] = None
     string_value: Optional[str] = None
@@ -42,11 +42,11 @@ class UnionType(Parsable):
             result.composed_type3 = values
         return result
 
-    def get_field_deserializers(self) -> Dict[str, Callable[[ParseNode], None]]:
+    def get_field_deserializers(self) -> dict[str, Callable[[ParseNode], None]]:
         """Gets the deserialization information for this object.
 
         Returns:
-            Dict[str, Callable[[ParseNode], None]]: The deserialization information for this
+            dict[str, Callable[[ParseNode], None]]: The deserialization information for this
             object where each entry is a property key with its deserialization callback.
         """
         if self.composed_type1:

--- a/packages/serialization/json/tests/helpers/union_type.py
+++ b/packages/serialization/json/tests/helpers/union_type.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Optional
 
 from kiota_abstractions.serialization import Parsable, ParseNode, SerializationWriter
 
@@ -14,7 +14,7 @@ class UnionType(Parsable):
     composed_type1: Optional[User] = None
     composed_type2: Optional[User2] = None
     string_value: Optional[str] = None
-    composed_type3: Optional[List[User]] = None
+    composed_type3: Optional[list[User]] = None
 
     @staticmethod
     def create_from_discriminator_value(parse_node: Optional[ParseNode] = None) -> UnionType:

--- a/packages/serialization/json/tests/helpers/union_type.py
+++ b/packages/serialization/json/tests/helpers/union_type.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any, Optional
 
 from kiota_abstractions.serialization import Parsable, ParseNode, SerializationWriter
 

--- a/packages/serialization/json/tests/helpers/user.py
+++ b/packages/serialization/json/tests/helpers/user.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 from uuid import UUID
 
 from kiota_abstractions.serialization import (
@@ -24,7 +24,7 @@ class User(Parsable, AdditionalDataHolder):
     office_location: Optional[OfficeLocation] = None
     updated_at: Optional[datetime] = None
     birthday: Optional[date] = None
-    business_phones: Optional[List[str]] = None
+    business_phones: Optional[list[str]] = None
     mobile_phone: Optional[str] = None
     is_active: Optional[bool] = None
 

--- a/packages/serialization/json/tests/helpers/user.py
+++ b/packages/serialization/json/tests/helpers/user.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 from uuid import UUID
 
 from kiota_abstractions.serialization import (
@@ -19,7 +19,7 @@ T = TypeVar('T')
 
 @dataclass
 class User(Parsable, AdditionalDataHolder):
-    additional_data: Dict[str, Any] = field(default_factory=dict)
+    additional_data: dict[str, Any] = field(default_factory=dict)
     id: Optional[UUID] = None
     office_location: Optional[OfficeLocation] = None
     updated_at: Optional[datetime] = None
@@ -40,11 +40,11 @@ class User(Parsable, AdditionalDataHolder):
             raise TypeError("parse_node cannot be null")
         return User()
 
-    def get_field_deserializers(self) -> Dict[str, Callable[[ParseNode], None]]:
+    def get_field_deserializers(self) -> dict[str, Callable[[ParseNode], None]]:
         """Gets the deserialization information for this object.
 
         Returns:
-            Dict[str, Callable[[ParseNode], None]]: The deserialization information for this
+            dict[str, Callable[[ParseNode], None]]: The deserialization information for this
             object where each entry is a property key with its deserialization callback.
         """
         return {

--- a/packages/serialization/json/tests/helpers/user.py
+++ b/packages/serialization/json/tests/helpers/user.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Any, Callable, Optional, TypeVar
+from collections.abc import Callable
+from typing import Any, Optional, TypeVar
 from uuid import UUID
 
 from kiota_abstractions.serialization import (

--- a/packages/serialization/json/tests/helpers/user2.py
+++ b/packages/serialization/json/tests/helpers/user2.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, TypeVar
+from collections.abc import Callable
+from typing import Any, Optional, TypeVar
 
 from kiota_abstractions.serialization import Parsable, ParseNode, SerializationWriter
 

--- a/packages/serialization/json/tests/helpers/user2.py
+++ b/packages/serialization/json/tests/helpers/user2.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
 from kiota_abstractions.serialization import Parsable, ParseNode, SerializationWriter
 
@@ -10,7 +10,7 @@ T = TypeVar('T')
 
 @dataclass
 class User2(Parsable):
-    additional_data: Dict[str, Any] = field(default_factory=dict)
+    additional_data: dict[str, Any] = field(default_factory=dict)
     id: Optional[int] = None
     display_name: Optional[str] = None
     age: Optional[int] = None
@@ -28,11 +28,11 @@ class User2(Parsable):
             raise TypeError("parse_node cannot be null")
         return User2()
 
-    def get_field_deserializers(self) -> Dict[str, Callable[[ParseNode], None]]:
+    def get_field_deserializers(self) -> dict[str, Callable[[ParseNode], None]]:
         """Gets the deserialization information for this object.
 
         Returns:
-            Dict[str, Callable[[ParseNode], None]]: The deserialization information for this
+            dict[str, Callable[[ParseNode], None]]: The deserialization information for this
             object where each entry is a property key with its deserialization callback.
         """
         return {

--- a/packages/serialization/multipart/kiota_serialization_multipart/multipart_serialization_writer.py
+++ b/packages/serialization/multipart/kiota_serialization_multipart/multipart_serialization_writer.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import io
+from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Optional, TypeVar
 from uuid import UUID
 
 from kiota_abstractions.multipart_body import MultipartBody

--- a/packages/serialization/multipart/kiota_serialization_multipart/multipart_serialization_writer.py
+++ b/packages/serialization/multipart/kiota_serialization_multipart/multipart_serialization_writer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 from uuid import UUID
 
 from kiota_abstractions.multipart_body import MultipartBody
@@ -184,10 +184,10 @@ class MultipartSerializationWriter(SerializationWriter):
         """
         raise NotImplementedError()
 
-    def write_additional_data_value(self, value: Dict[str, Any]) -> None:
+    def write_additional_data_value(self, value: dict[str, Any]) -> None:
         """Writes the specified additional data to the stream.
         Args:
-            value (Dict[str, Any]): he additional data to be written.
+            value (dict[str, Any]): he additional data to be written.
         """
         raise NotImplementedError()
 

--- a/packages/serialization/multipart/kiota_serialization_multipart/multipart_serialization_writer.py
+++ b/packages/serialization/multipart/kiota_serialization_multipart/multipart_serialization_writer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 from uuid import UUID
 
 from kiota_abstractions.multipart_body import MultipartBody
@@ -120,23 +120,23 @@ class MultipartSerializationWriter(SerializationWriter):
             self._stream.write(value)
 
     def write_collection_of_primitive_values(
-        self, key: Optional[str], values: Optional[List[T]]
+        self, key: Optional[str], values: Optional[list[T]]
     ) -> None:
         """Writes the specified collection of primitive values to the stream with an optional
         given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values (Optional[List[T]]): The collection of primitive values to be written.
+            values (Optional[list[T]]): The collection of primitive values to be written.
         """
         raise NotImplementedError()
 
     def write_collection_of_enum_values(
-        self, key: Optional[str], values: Optional[List[K]]
+        self, key: Optional[str], values: Optional[list[K]]
     ) -> None:
         """Writes the specified collection of enum values to the stream with an optional given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values Optional[List[K]): The enum values to be written.
+            values Optional[list[K]): The enum values to be written.
         """
         raise NotImplementedError()
 
@@ -149,13 +149,13 @@ class MultipartSerializationWriter(SerializationWriter):
         raise NotImplementedError()
 
     def write_collection_of_object_values(
-        self, key: Optional[str], values: Optional[List[U]]
+        self, key: Optional[str], values: Optional[list[U]]
     ) -> None:
         """Writes the specified collection of model objects to the stream with an optional
         given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values (Optional[List[U]]): The collection of model objects to be written.
+            values (Optional[list[U]]): The collection of model objects to be written.
         """
         raise NotImplementedError()
 

--- a/packages/serialization/multipart/pyproject.toml
+++ b/packages/serialization/multipart/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 keywords = ["kiota", "openAPI", "Microsoft", "Graph"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -24,7 +23,7 @@ documentation = "https://learn.microsoft.com/openapi/kiota/"
 packages = [{include = "kiota_serialization_multipart"}]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 microsoft-kiota-abstractions = {path="../../abstractions/", develop=true}
 pendulum = ">=3.0.0b1"
 

--- a/packages/serialization/multipart/tests/helpers/test_entity.py
+++ b/packages/serialization/multipart/tests/helpers/test_entity.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, time
-from typing import Any, Callable, Optional, TypeVar
+from collections.abc import Callable
+from typing import Any, Optional, TypeVar
 from uuid import UUID
 
 from kiota_abstractions.serialization import (

--- a/packages/serialization/multipart/tests/helpers/test_entity.py
+++ b/packages/serialization/multipart/tests/helpers/test_entity.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, time
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 from uuid import UUID
 
 from kiota_abstractions.serialization import (
@@ -20,7 +20,7 @@ T = TypeVar('T')
 class TestEntity(Parsable, AdditionalDataHolder):
     additional_data: dict[str, Any] = field(default_factory=dict)
     id: Optional[UUID] = None
-    device_names: Optional[List[str]] = None
+    device_names: Optional[list[str]] = None
     numbers: Optional[TestEnum] = None
     work_duration: Optional[timedelta] = None
     birthday: Optional[date] = None

--- a/packages/serialization/multipart/tests/helpers/test_entity.py
+++ b/packages/serialization/multipart/tests/helpers/test_entity.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, time
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 from uuid import UUID
 
 from kiota_abstractions.serialization import (
@@ -18,7 +18,7 @@ T = TypeVar('T')
 
 @dataclass
 class TestEntity(Parsable, AdditionalDataHolder):
-    additional_data: Dict[str, Any] = field(default_factory=dict)
+    additional_data: dict[str, Any] = field(default_factory=dict)
     id: Optional[UUID] = None
     device_names: Optional[List[str]] = None
     numbers: Optional[TestEnum] = None
@@ -41,11 +41,11 @@ class TestEntity(Parsable, AdditionalDataHolder):
             raise TypeError("parse_node cannot be null")
         return TestEntity()
 
-    def get_field_deserializers(self) -> Dict[str, Callable[[ParseNode], None]]:
+    def get_field_deserializers(self) -> dict[str, Callable[[ParseNode], None]]:
         """Gets the deserialization information for this object.
 
         Returns:
-            Dict[str, Callable[[ParseNode], None]]: The deserialization information for this
+            dict[str, Callable[[ParseNode], None]]: The deserialization information for this
             object where each entry is a property key with its deserialization callback.
         """
         return {

--- a/packages/serialization/text/kiota_serialization_text/text_parse_node.py
+++ b/packages/serialization/text/kiota_serialization_text/text_parse_node.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import base64
+from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Callable, Optional, TypeVar
+from typing import Optional, TypeVar
 from uuid import UUID
 
 from dateutil import parser

--- a/packages/serialization/text/kiota_serialization_text/text_parse_node.py
+++ b/packages/serialization/text/kiota_serialization_text/text_parse_node.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Generic, List, Optional, TypeVar
+from typing import Callable, Optional, TypeVar
 from uuid import UUID
 
 from dateutil import parser
@@ -133,26 +133,26 @@ class TextParseNode(ParseNode):
             return datetime_obj.time()
         return None
 
-    def get_collection_of_primitive_values(self, primitive_type: type[T]) -> List[T]:
+    def get_collection_of_primitive_values(self, primitive_type: type[T]) -> list[T]:
         """Gets the collection of primitive values of the node
         Args:
             primitive_type: The type of primitive to return.
         Returns:
-            List[T]: The collection of primitive values
+            list[T]: The collection of primitive values
         """
         raise Exception(self.NO_STRUCTURED_DATA_MESSAGE)
 
-    def get_collection_of_object_values(self, factory: ParsableFactory[U]) -> List[U]:
+    def get_collection_of_object_values(self, factory: ParsableFactory[U]) -> list[U]:
         """Gets the collection of type U values from the text node
         Returns:
-            List[U]: The collection of model object values of the node
+            list[U]: The collection of model object values of the node
         """
         raise Exception(self.NO_STRUCTURED_DATA_MESSAGE)
 
-    def get_collection_of_enum_values(self, enum_class: K) -> Optional[List[K]]:
+    def get_collection_of_enum_values(self, enum_class: K) -> Optional[list[K]]:
         """Gets the collection of enum values of the text node
         Returns:
-            List[K]: The collection of enum values
+            list[K]: The collection of enum values
         """
         raise Exception(self.NO_STRUCTURED_DATA_MESSAGE)
 

--- a/packages/serialization/text/kiota_serialization_text/text_serialization_writer.py
+++ b/packages/serialization/text/kiota_serialization_text/text_serialization_writer.py
@@ -1,7 +1,7 @@
 import base64
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 from uuid import UUID
 
 from kiota_abstractions.serialization import Parsable, SerializationWriter
@@ -113,34 +113,34 @@ class TextSerializationWriter(SerializationWriter):
             self.write_str_value(key, str(value))
 
     def write_collection_of_primitive_values(
-        self, key: Optional[str], values: Optional[List[T]]
+        self, key: Optional[str], values: Optional[list[T]]
     ) -> None:
         """Writes the specified collection of primitive values to the stream with an optional
         given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values (Optional[List[T]]): The collection of primitive values to be written.
+            values (Optional[list[T]]): The collection of primitive values to be written.
         """
         raise Exception(self.NO_STRUCTURED_DATA_MESSAGE)
 
     def write_collection_of_object_values(
-        self, key: Optional[str], values: Optional[List[U]]
+        self, key: Optional[str], values: Optional[list[U]]
     ) -> None:
         """Writes the specified collection of model objects to the stream with an optional
         given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values (Optional[List[U]]): The collection of model objects to be written.
+            values (Optional[list[U]]): The collection of model objects to be written.
         """
         raise Exception(self.NO_STRUCTURED_DATA_MESSAGE)
 
     def write_collection_of_enum_values(
-        self, key: Optional[str], values: Optional[List[K]]
+        self, key: Optional[str], values: Optional[list[K]]
     ) -> None:
         """Writes the specified collection of enum values to the stream with an optional given key.
         Args:
             key (Optional[str]): The key to be used for the written value. May be null.
-            values Optional[List[K]): The enum values to be written.
+            values Optional[list[K]): The enum values to be written.
         """
         raise Exception(self.NO_STRUCTURED_DATA_MESSAGE)
 

--- a/packages/serialization/text/kiota_serialization_text/text_serialization_writer.py
+++ b/packages/serialization/text/kiota_serialization_text/text_serialization_writer.py
@@ -1,7 +1,7 @@
 import base64
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 from uuid import UUID
 
 from kiota_abstractions.serialization import Parsable, SerializationWriter
@@ -186,10 +186,10 @@ class TextSerializationWriter(SerializationWriter):
         """
         self.write_str_value(key, 'null')
 
-    def write_additional_data_value(self, value: Dict[str, Any]) -> None:
+    def write_additional_data_value(self, value: dict[str, Any]) -> None:
         """Writes the specified additional data to the stream.
         Args:
-            value (Dict[str, Any]): he additional data to be written.
+            value (dict[str, Any]): he additional data to be written.
         """
         raise Exception(self.NO_STRUCTURED_DATA_MESSAGE)
 

--- a/packages/serialization/text/kiota_serialization_text/text_serialization_writer.py
+++ b/packages/serialization/text/kiota_serialization_text/text_serialization_writer.py
@@ -1,7 +1,8 @@
 import base64
+from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Optional, TypeVar
 from uuid import UUID
 
 from kiota_abstractions.serialization import Parsable, SerializationWriter

--- a/packages/serialization/text/pyproject.toml
+++ b/packages/serialization/text/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 keywords = ["kiota", "openAPI", "Microsoft", "Graph"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -24,7 +23,7 @@ documentation = "https://learn.microsoft.com/openapi/kiota/"
 packages = [{include = "kiota_serialization_text"}]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 microsoft-kiota-abstractions = {path="../../abstractions/", develop=true}
 python-dateutil = "2.9.0.post0"
 

--- a/packages/serialization/text/tests/helpers/user.py
+++ b/packages/serialization/text/tests/helpers/user.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Optional, TypeVar
+from collections.abc import Callable
 
 from kiota_abstractions.serialization import (
     AdditionalDataHolder,

--- a/packages/serialization/text/tests/helpers/user.py
+++ b/packages/serialization/text/tests/helpers/user.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from dataclasses import dataclass, field
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
 from kiota_abstractions.serialization import (
     AdditionalDataHolder,
@@ -24,7 +24,7 @@ class User(Parsable, AdditionalDataHolder):
     office_location: Optional[OfficeLocation] = None
     updated_at: Optional[datetime] = None
     birthday: Optional[date] = None
-    business_phones: Optional[List[str]] = None
+    business_phones: Optional[list[str]] = None
     mobile_phone: Optional[str] = None
     is_active: Optional[bool] = None
     age: Optional[int] = None

--- a/packages/serialization/text/tests/helpers/user.py
+++ b/packages/serialization/text/tests/helpers/user.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 
 from kiota_abstractions.serialization import (
     AdditionalDataHolder,
@@ -29,7 +29,7 @@ class User(Parsable, AdditionalDataHolder):
     is_active: Optional[bool] = None
     age: Optional[int] = None
     gpa: Optional[float] = None
-    additional_data: Dict[str, Any] = field(default_factory=dict)
+    additional_data: dict[str, Any] = field(default_factory=dict)
 
     @staticmethod
     def create_from_discriminator_value(parse_node: Optional[ParseNode] = None) -> User:
@@ -43,11 +43,11 @@ class User(Parsable, AdditionalDataHolder):
             raise Exception("parse_node cannot be undefined")
         return User()
 
-    def get_field_deserializers(self) -> Dict[str, Callable[[ParseNode], None]]:
+    def get_field_deserializers(self) -> dict[str, Callable[[ParseNode], None]]:
         """Gets the deserialization information for this object.
 
         Returns:
-            Dict[str, Callable[[ParseNode], None]]: The deserialization information for this
+            dict[str, Callable[[ParseNode], None]]: The deserialization information for this
             object where each entry is a property key with its deserialization callback.
         """
         return {

--- a/tests/validation/pyproject.toml
+++ b/tests/validation/pyproject.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 keywords = ["kiota", "openAPI", "Microsoft", "Graph"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -25,7 +24,7 @@ documentation = "https://learn.microsoft.com/openapi/kiota/"
 packages = [{include = "kiota_abstractions"}]	
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 microsoft-kiota-abstractions = {path="../../packages/abstractions/", develop=true}
 microsoft-kiota-http = {path="../../packages/http/httpx/", develop=true}
 microsoft-kiota-serialization-json = {path="../../packages/serialization/json/", develop=true}


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota-python/issues/349

This PR drops support for python 3.8 in the kiota libraries.

In summary, the changes include
- Dropping using of collection type hint aliases such as Dict, Set and List from typing. 
- Updates projects requirements to include python 3.9+ and drop 3.8
- Updates validation client to use non deprecated hints via https://github.com/microsoft/kiota-python/pull/434