### PR TITLE
docs: DevContainer added and explained

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// "image": "mcr.microsoft.com/devcontainers/python:3.9-bookworm",
+	// "image": "mcr.microsoft.com/devcontainers/python:3.10-bookworm",
+	// "image": "mcr.microsoft.com/devcontainers/python:3.11-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/python:3.12-bookworm",
+	// "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+
+	"features": {
+		"ghcr.io/hspaans/devcontainer-features/pytest:1": {},
+		"ghcr.io/devcontainers-extra/features/pylint:2": {},
+		"ghcr.io/devcontainers-extra/features/poetry:2": {},
+		"ghcr.io/devcontainers/features/powershell:1": {}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "git config --global core.autocrlf true && pip3 install --user -r requirements_dev.txt && pwsh -File kiota-python.ps1 install-deps",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"wmiller4.python-venv-switcher"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+  "python.testing.cwd": ".",
+  // "python.poetryPath": ".venv/bin/poetry",
+  // "python.testing.pytestPath": ".venv/bin/pytest",
+  // "python.analysis.typeCheckingMode": "basic",
+  "python.testing.pytestArgs": [
+    "packages/tests",
+    "packages/abstractions/tests",
+    "packages/authentication/tests",
+    "packages/bundle/tests",
+    "packages/http/tests",
+    "packages/serialization/form/tests",
+    "packages/serialization/json/tests",
+    "packages/serialization/multipart/tests",
+    "packages/serialization/text/tests",
+    "--rootdir=${workspaceFolder}"
+  ],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": false, // Disable pytest (does not work with poetry yet)
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,132 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "poetry:deps",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "--File",
+        "kiota-python.ps1",
+        "install-deps"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}",
+      },
+      "problemMatcher": [
+        "$python"
+      ]
+    },
+    {
+      "label": "poetry:format",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "--File",
+        "kiota-python.ps1",
+        "format"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}",
+      },
+      "problemMatcher": [
+        "$python"
+      ]
+    },
+    {
+      "label": "poetry:check-format",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "--File",
+        "kiota-python.ps1",
+        "check-format"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}",
+      },
+      "problemMatcher": [
+        "$python"
+      ]
+    },
+    {
+      "label": "poetry:lint",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "--File",
+        "kiota-python.ps1",
+        "lint"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}",
+      },
+      "problemMatcher": [
+        "$python"
+      ]
+    },
+    {
+      "label": "poetry:check-types",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "--File",
+        "kiota-python.ps1",
+        "test"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}",
+      },
+      "problemMatcher": [
+        "$python"
+      ]
+    },
+    {
+      "label": "poetry:test",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "--File",
+        "kiota-python.ps1",
+        "test"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}",
+      },
+      "problemMatcher": [
+        "$python"
+      ]
+    },
+    {
+      "label": "poetry:check-all",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "--File",
+        "kiota-python.ps1",
+        "test"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}",
+      },
+      "problemMatcher": [
+        "$python"
+      ]
+    },
+    {
+      "label": "pre-commit",
+      "type": "shell",
+      "command": "echo",
+      "args": [
+        "All tests executed"
+      ],
+      "dependsOn":[
+        "poetry:format",
+        "poetry:check-all"
+      ]
+    }
+    
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 
-# Contributing to Kiota Java
+# Contributing to Kiota Python
 
 Kiota Python is a mono-repo containing source code for the following packages:
 
@@ -142,3 +142,42 @@ To run type checking using `mypy` across all projects, run the following in a po
 ```
 
 __TIP__ Running `.\kiota-python.ps1 test` should give a hint of all available commands you can pass to the script to run across projects which can be configured this in [this file](./projects-config.json).
+
+
+## Dev Container
+
+This repository is setup to use [Visual Studio Code Dev Containers](https://code.visualstudio.com/docs/remote/containers) to provide a consistent development environment for contributors. The dev container is configured to have all the necessary tools and dependencies to work on the repository.
+
+By default we do all development in `Python 3.12`, but we support Python 3.9, 3.10, 3.11, and 3.12. The dev container is configured to use Python 3.12, but you can test your changes by changing the `"image": "mcr.microsoft.com/devcontainers/python:3.12-bookworm",` line in the `.devcontainer/devcontainer.json` file to the desired version. If you save changes to this file, you will be prompted to rebuild the dev container. You can also rebuild the dev container by running the `Remote-Containers: Rebuild Container` command from the command palette.
+
+### Dependencies
+
+Upon loading the dev container the `pwsh -File ./kiota-python.ps1 install-deps` command will be run to install the necessary dependencies for the repository. You can also run this command manually by Running the `poetry:deps` task from the VSCode command `Run Task` palette.
+
+Or run the following command in the terminal:
+
+```shell
+pwsh -File ./kiota-python.ps1 install-deps
+```
+
+### Running Tests
+
+To run the tests in the dev container, you can run the `poetry:test` task from the VSCode command `Run Task` palette.
+
+Or run the following command in the terminal:
+
+```shell
+pwsh -File ./kiota-python.ps1 test
+```
+
+### Pre-commit tests
+
+All PR's are tested by the GitHub Actions workflow. To tacle issues before committing, it is adviced to run the `pre-commit` task from the VSCode command `Run Task` palette. This will format your code and run the same checks that are run in the GitHub Actions workflow.
+
+Or run the following command in the terminal:
+
+```shell
+pwsh -File ./kiota-python.ps1 format
+pwsh -File ./kiota-python.ps1 check-all
+```
+

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,2 @@
+pylint==3.2.7
+poetry-plugin-mono-repo-deps==0.3.0


### PR DESCRIPTION


## Overview

Trying to make life easier for new contributors to this project by adding a dev container and additional docs Fixed Provide DevContainer with tests configured #453

## Related Issue

Fixes #453

### Demo

![image](https://github.com/user-attachments/assets/da5a58ec-25c6-46bc-80f7-96195ddbbfc7)

### Notes

Integration with the test extension in VSCode still does not work, this would be an even better addition. Has to do with poetry and the test extension, that don't play nice together.
