### PR TITLE
Fix base_url usage in HttpxRequestAdapter

### DIFF
--- a/packages/http/httpx/kiota_http/httpx_request_adapter.py
+++ b/packages/http/httpx/kiota_http/httpx_request_adapter.py
@@ -88,7 +88,7 @@ class HttpxRequestAdapter(RequestAdapter):
             http_client = KiotaClientFactory.create_with_default_middleware()
         self._http_client = http_client
         if not base_url:
-            base_url = ""
+            base_url = str(http_client.base_url)
         self._base_url: str = base_url
         if not observability_options:
             observability_options = ObservabilityOptions()
@@ -101,7 +101,7 @@ class HttpxRequestAdapter(RequestAdapter):
         Returns:
             str: The base url
         """
-        return self._base_url
+        return self._base_url or str(self._http_client.base_url)
 
     @base_url.setter
     def base_url(self, value: str) -> None:

--- a/packages/http/httpx/tests/test_httpx_request_adapter.py
+++ b/packages/http/httpx/tests/test_httpx_request_adapter.py
@@ -400,3 +400,9 @@ async def test_retries_on_cae_failure(
         ),
     ]
     request_adapter._authentication_provider.authenticate_request.assert_has_awaits(calls)
+
+
+def test_httpx_request_adapter_uses_http_client_base_url(auth_provider):
+    http_client = httpx.AsyncClient(base_url=BASE_URL)
+    request_adapter = HttpxRequestAdapter(auth_provider, http_client=http_client)
+    assert request_adapter.base_url == BASE_URL


### PR DESCRIPTION
Fixes #374

Modify `HttpxRequestAdapter` to use `http_client.base_url` if `base_url` is not explicitly set.

* Update the constructor in `packages/http/httpx/kiota_http/httpx_request_adapter.py` to check and use `http_client.base_url` if `base_url` is not provided.
* Update the `base_url` property to return `http_client.base_url` if `_base_url` is not set.
* Add a test in `packages/http/httpx/tests/test_httpx_request_adapter.py` to verify that `HttpxRequestAdapter` uses `http_client.base_url` if `base_url` is not explicitly set.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/kiota-python/issues/374?shareId=XXXX-XXXX-XXXX-XXXX).