### PR TITLE
Ensure 304 status code does not throw, but returns None instead

### DIFF
--- a/packages/http/httpx/kiota_http/httpx_request_adapter.py
+++ b/packages/http/httpx/kiota_http/httpx_request_adapter.py
@@ -463,6 +463,7 @@ class HttpxRequestAdapter(RequestAdapter):
             attribute_span.record_exception(exc)
             _throw_failed_resp_span.end()
             raise exc
+        return True
 
     async def throw_failed_responses(
         self,
@@ -473,7 +474,7 @@ class HttpxRequestAdapter(RequestAdapter):
     ) -> None:
         if response.is_success or response.status_code == 304:
             return
-        if self._is_redirect_missing_location(response, parent_span, attribute_span) == False:
+        if self._is_redirect_missing_location(response, parent_span, attribute_span) is False:
             return
         try:
             attribute_span.set_status(trace.StatusCode.ERROR)

--- a/packages/http/httpx/kiota_http/httpx_request_adapter.py
+++ b/packages/http/httpx/kiota_http/httpx_request_adapter.py
@@ -468,7 +468,7 @@ class HttpxRequestAdapter(RequestAdapter):
     async def _get_error_from_response(
         self,
         response: httpx.Response,
-        error_map: Optional[dict[str, type[ParsableFactory]]],
+        error_map: dict[str, type[ParsableFactory]],
         response_status_code_str: str,
         response_status_code: int,
         attribute_span: trace.Span,

--- a/packages/http/httpx/kiota_http/httpx_request_adapter.py
+++ b/packages/http/httpx/kiota_http/httpx_request_adapter.py
@@ -423,7 +423,7 @@ class HttpxRequestAdapter(RequestAdapter):
             span.end()
 
     def _should_return_none(self, response: httpx.Response) -> bool:
-        return response.status_code == 204 or not bool(response.content)
+        return response.status_code == 204 or response.status_code == 304 or not bool(response.content)
 
     async def throw_failed_responses(
         self,

--- a/packages/http/httpx/kiota_http/httpx_request_adapter.py
+++ b/packages/http/httpx/kiota_http/httpx_request_adapter.py
@@ -440,7 +440,9 @@ class HttpxRequestAdapter(RequestAdapter):
             response.content
         ) or (not response.headers.get("location") and response.status_code in [301, 302])
 
-    def _is_redirect_missing_location(self, response: httpx.Response, parent_span: trace.Span, attribute_span: trace.Span) -> bool:
+    def _is_redirect_missing_location(
+        self, response: httpx.Response, parent_span: trace.Span, attribute_span: trace.Span
+    ) -> bool:
         if response.is_redirect:
             if response.has_redirect_location:
                 return False
@@ -453,7 +455,7 @@ class HttpxRequestAdapter(RequestAdapter):
             _throw_failed_resp_span.set_attribute("status", response.status_code)
             exc = APIError(
                 f"The server returned a redirect status code {response.status_code}"
-                 " without a location header",
+                " without a location header",
                 response.status_code,
                 response.headers,  # type: ignore
             )

--- a/packages/http/httpx/kiota_http/httpx_request_adapter.py
+++ b/packages/http/httpx/kiota_http/httpx_request_adapter.py
@@ -425,7 +425,7 @@ class HttpxRequestAdapter(RequestAdapter):
             span.end()
 
     def _should_return_none(self, response: httpx.Response) -> bool:
-        return response.status_code == 204 or response.status_code == 304 or not bool(response.content)
+        return response.status_code == 204 or response.status_code == 304 or not bool(response.content) or (not response.headers.get("Location") and response.status_code in [301, 302])
 
     async def throw_failed_responses(
         self,

--- a/packages/http/httpx/tests/test_httpx_request_adapter.py
+++ b/packages/http/httpx/tests/test_httpx_request_adapter.py
@@ -400,3 +400,16 @@ async def test_retries_on_cae_failure(
         ),
     ]
     request_adapter._authentication_provider.authenticate_request.assert_has_awaits(calls)
+
+
+@pytest.mark.asyncio
+async def test_send_primitive_async_304_no_location_header_returns_null(
+    request_adapter, request_info
+):
+    mock_304_response = httpx.Response(status_code=304, headers={"Content-Type": "application/json"})
+    request_adapter.get_http_response_message = AsyncMock(return_value=mock_304_response)
+    resp = await request_adapter.get_http_response_message(request_info)
+    assert resp.status_code == 304
+    assert "location" not in resp.headers
+    final_result = await request_adapter.send_primitive_async(request_info, "float", {})
+    assert final_result is None

--- a/packages/http/httpx/tests/test_httpx_request_adapter.py
+++ b/packages/http/httpx/tests/test_httpx_request_adapter.py
@@ -402,12 +402,13 @@ async def test_retries_on_cae_failure(
     request_adapter._authentication_provider.authenticate_request.assert_has_awaits(calls)
 
 
-
 @pytest.mark.asyncio
 async def test_send_primitive_async_304_no_location_header_returns_null(
     request_adapter, request_info
 ):
-    mock_304_response = httpx.Response(status_code=304, headers={"Content-Type": "application/json"})
+    mock_304_response = httpx.Response(
+        status_code=304, headers={"Content-Type": "application/json"}
+    )
     request_adapter.get_http_response_message = AsyncMock(return_value=mock_304_response)
     resp = await request_adapter.get_http_response_message(request_info)
     assert resp.status_code == 304
@@ -417,10 +418,10 @@ async def test_send_primitive_async_304_no_location_header_returns_null(
 
 
 @pytest.mark.asyncio
-async def test_send_primitive_async_301_no_location_header_throws(
-    request_adapter, request_info
-):
-    mock_301_response = httpx.Response(status_code=301, headers={"Content-Type": "application/json"})
+async def test_send_primitive_async_301_no_location_header_throws(request_adapter, request_info):
+    mock_301_response = httpx.Response(
+        status_code=301, headers={"Content-Type": "application/json"}
+    )
     request_adapter.get_http_response_message = AsyncMock(return_value=mock_301_response)
     resp = await request_adapter.get_http_response_message(request_info)
     assert resp.status_code == 301
@@ -435,7 +436,13 @@ async def test_send_primitive_async_301_no_location_header_throws(
 async def test_send_primitive_async_302_with_location_header_does_not_throw(
     request_adapter, request_info
 ):
-    mock_302_response = httpx.Response(status_code=302, headers={"Content-Type": "application/json", "location": "https://example.com"})
+    mock_302_response = httpx.Response(
+        status_code=302,
+        headers={
+            "Content-Type": "application/json",
+            "location": "https://example.com"
+        }
+    )
     request_adapter.get_http_response_message = AsyncMock(return_value=mock_302_response)
     resp = await request_adapter.get_http_response_message(request_info)
     assert resp.status_code == 302
@@ -447,4 +454,3 @@ def test_httpx_request_adapter_uses_http_client_base_url(auth_provider):
     http_client = httpx.AsyncClient(base_url=BASE_URL)
     request_adapter = HttpxRequestAdapter(auth_provider, http_client=http_client)
     assert request_adapter.base_url == BASE_URL
-

--- a/packages/http/httpx/tests/test_httpx_request_adapter.py
+++ b/packages/http/httpx/tests/test_httpx_request_adapter.py
@@ -416,6 +416,33 @@ async def test_send_primitive_async_304_no_location_header_returns_null(
     assert final_result is None
 
 
+@pytest.mark.asyncio
+async def test_send_primitive_async_301_no_location_header_throws(
+    request_adapter, request_info
+):
+    mock_301_response = httpx.Response(status_code=301, headers={"Content-Type": "application/json"})
+    request_adapter.get_http_response_message = AsyncMock(return_value=mock_301_response)
+    resp = await request_adapter.get_http_response_message(request_info)
+    assert resp.status_code == 301
+    assert "location" not in resp.headers
+    with pytest.raises(APIError) as e:
+        final_result = await request_adapter.send_primitive_async(request_info, "float", {})
+    assert e is not None
+    assert e.value.response_status_code == 301
+
+
+@pytest.mark.asyncio
+async def test_send_primitive_async_302_with_location_header_does_not_throw(
+    request_adapter, request_info
+):
+    mock_302_response = httpx.Response(status_code=302, headers={"Content-Type": "application/json", "location": "https://example.com"})
+    request_adapter.get_http_response_message = AsyncMock(return_value=mock_302_response)
+    resp = await request_adapter.get_http_response_message(request_info)
+    assert resp.status_code == 302
+    assert "location" in resp.headers
+    final_result = await request_adapter.send_primitive_async(request_info, "float", {})
+
+
 def test_httpx_request_adapter_uses_http_client_base_url(auth_provider):
     http_client = httpx.AsyncClient(base_url=BASE_URL)
     request_adapter = HttpxRequestAdapter(auth_provider, http_client=http_client)

--- a/packages/http/httpx/tests/test_httpx_request_adapter.py
+++ b/packages/http/httpx/tests/test_httpx_request_adapter.py
@@ -426,7 +426,7 @@ async def test_send_primitive_async_301_no_location_header_throws(
     assert resp.status_code == 301
     assert "location" not in resp.headers
     with pytest.raises(APIError) as e:
-        final_result = await request_adapter.send_primitive_async(request_info, "float", {})
+        await request_adapter.send_primitive_async(request_info, "float", {})
     assert e is not None
     assert e.value.response_status_code == 301
 
@@ -440,7 +440,7 @@ async def test_send_primitive_async_302_with_location_header_does_not_throw(
     resp = await request_adapter.get_http_response_message(request_info)
     assert resp.status_code == 302
     assert "location" in resp.headers
-    final_result = await request_adapter.send_primitive_async(request_info, "float", {})
+    await request_adapter.send_primitive_async(request_info, "float", {})
 
 
 def test_httpx_request_adapter_uses_http_client_base_url(auth_provider):


### PR DESCRIPTION
Fixes #363

Add handling for 304 responses without a location header in request adapter.

* Modify `packages/http/httpx/kiota_http/httpx_request_adapter.py` to include a check for 304 status code in `_should_return_none` method.
  * Return True if the status code is 304 and there is no location header.
* Add a unit test in `packages/http/httpx/tests/test_httpx_request_adapter.py` to verify that the request adapter returns null and does not throw for a 304 response without a location header.
  * Create a mock 304 response without a location header.
  * Ensure the unit test checks that the request adapter returns null for the 304 response.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/kiota-python/pull/460?shareId=b8cffb0f-568e-4b4b-8a71-fefae2b14284).