### PR TITLE
Throw error on `https://` and `http://` prefix if present in allowed host value

### DIFF
--- a/packages/abstractions/kiota_abstractions/authentication/allowed_hosts_validator.py
+++ b/packages/abstractions/kiota_abstractions/authentication/allowed_hosts_validator.py
@@ -16,6 +16,10 @@ class AllowedHostsValidator:
         if not isinstance(allowed_hosts, list):
             raise TypeError("Allowed hosts must be a list of strings")
 
+        for host in allowed_hosts:
+            if host.startswith("https://") or host.startswith("http://"):
+                raise ValueError("Allowed host value cannot contain 'https://' or 'http://' prefix")
+
         self.allowed_hosts: set[str] = {x.lower() for x in allowed_hosts}
 
     def get_allowed_hosts(self) -> list[str]:
@@ -35,6 +39,11 @@ class AllowedHostsValidator:
         """
         if not isinstance(allowed_hosts, list):
             raise TypeError("Allowed hosts must be a list of strings")
+
+        for host in allowed_hosts:
+            if host.startswith("https://") or host.startswith("http://"):
+                raise ValueError("Allowed host value cannot contain 'https://' or 'http://' prefix")
+
         self.allowed_hosts = {x.lower() for x in allowed_hosts}
 
     def is_url_host_valid(self, url: str) -> bool:

--- a/packages/abstractions/tests/authentication/test_api_key_authentication_provider.py
+++ b/packages/abstractions/tests/authentication/test_api_key_authentication_provider.py
@@ -2,7 +2,7 @@ import pytest
 
 from kiota_abstractions.authentication import ApiKeyAuthenticationProvider, AuthenticationProvider, KeyLocation
 
-allowed_hosts = ["https://example.com"]
+allowed_hosts = ["example.com"]
 
 
 def test_initialization():

--- a/packages/abstractions/tests/authentication/test_api_key_authentication_provider.py
+++ b/packages/abstractions/tests/authentication/test_api_key_authentication_provider.py
@@ -59,3 +59,17 @@ async def test_header_location_authentication(mock_request_information):
     await provider.authenticate_request(mock_request_information)
     assert "api_key" in mock_request_information.request_headers
     assert mock_request_information.headers.get("api_key") == {"test_key_string"}
+
+
+def test_https_prefix_in_allowed_host():
+    with pytest.raises(ValueError, match="Allowed host value cannot contain 'https://' or 'http://' prefix"):
+        ApiKeyAuthenticationProvider(
+            KeyLocation.Header, "test_key_string", "api_key", ["https://example.com"]
+        )
+
+
+def test_http_prefix_in_allowed_host():
+    with pytest.raises(ValueError, match="Allowed host value cannot contain 'https://' or 'http://' prefix"):
+        ApiKeyAuthenticationProvider(
+            KeyLocation.Header, "test_key_string", "api_key", ["http://example.com"]
+        )


### PR DESCRIPTION
Fixes #201

Add error handling for 'https://' and 'http://' prefixes in allowed host values.

* Modify `AllowedHostsValidator` class in `packages/abstractions/kiota_abstractions/authentication/allowed_hosts_validator.py` to throw a `ValueError` if any allowed host contains 'https://' or 'http://' prefix.
* Add a check in the `__init__` method and `set_allowed_hosts` method to throw a `ValueError` if any allowed host contains 'https://' or 'http://' prefix.
* Add tests in `packages/abstractions/tests/authentication/test_api_key_authentication_provider.py` to verify that a `ValueError` is thrown when 'https://' or 'http://' prefix is present in allowed host value.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/kiota-python/pull/461?shareId=ae5c7a0b-5a46-4048-95cc-82008be7325e).