### PR TITLE
serialize objects to bytes in a JSON compatible way

### DIFF
--- a/packages/serialization/json/kiota_serialization_json/json_parse_node.py
+++ b/packages/serialization/json/kiota_serialization_json/json_parse_node.py
@@ -233,7 +233,7 @@ class JsonParseNode(ParseNode):
         Returns:
             bytearray: The bytearray value from the nodes
         """
-        base64_string = str(self._json_node)
+        base64_string = json.dumps(self._json_node)
         if not base64_string:
             return None
         return base64_string.encode("utf-8")

--- a/packages/serialization/json/kiota_serialization_json/json_parse_node.py
+++ b/packages/serialization/json/kiota_serialization_json/json_parse_node.py
@@ -233,7 +233,7 @@ class JsonParseNode(ParseNode):
         Returns:
             bytearray: The bytearray value from the nodes
         """
-        if isinstance(self._json_node, str)
+        if isinstance(self._json_node, str):
             base64_string = self._json_node
         else:
             base64_string = json.dumps(self._json_node)

--- a/packages/serialization/json/kiota_serialization_json/json_parse_node.py
+++ b/packages/serialization/json/kiota_serialization_json/json_parse_node.py
@@ -233,7 +233,10 @@ class JsonParseNode(ParseNode):
         Returns:
             bytearray: The bytearray value from the nodes
         """
-        base64_string = json.dumps(self._json_node)
+        if isinstance(self._json_node, list) or isinstance(self._json_node, dict):
+            base64_string = json.dumps(self._json_node)
+        else:
+            base64_string = str(self._json_node)
         if not base64_string:
             return None
         return base64_string.encode("utf-8")

--- a/packages/serialization/json/kiota_serialization_json/json_parse_node.py
+++ b/packages/serialization/json/kiota_serialization_json/json_parse_node.py
@@ -233,10 +233,10 @@ class JsonParseNode(ParseNode):
         Returns:
             bytearray: The bytearray value from the nodes
         """
-        if isinstance(self._json_node, list) or isinstance(self._json_node, dict):
-            base64_string = json.dumps(self._json_node)
+        if isinstance(self._json_node, str)
+            base64_string = self._json_node
         else:
-            base64_string = str(self._json_node)
+            base64_string = json.dumps(self._json_node)
         if not base64_string:
             return None
         return base64_string.encode("utf-8")

--- a/packages/serialization/json/tests/unit/test_json_parse_node.py
+++ b/packages/serialization/json/tests/unit/test_json_parse_node.py
@@ -110,6 +110,12 @@ def test_get_bytes_value():
     assert isinstance(result, bytes)
 
 
+def test_get_bytes_json_compatible():
+    parse_node = JsonParseNode({"test": 1})
+    result = parse_node.get_bytes_value()
+    assert json.loads(result.decode("utf-8")) == {"test": 1}
+
+
 def test_get_collection_of_enum_values():
     parse_node = JsonParseNode(["dunhill", "oval"])
     result = parse_node.get_collection_of_enum_values(OfficeLocation)

--- a/packages/serialization/json/tests/unit/test_json_parse_node.py
+++ b/packages/serialization/json/tests/unit/test_json_parse_node.py
@@ -108,6 +108,7 @@ def test_get_bytes_value():
     parse_node = JsonParseNode("U2Ftd2VsIGlzIHRoZSBiZXN0")
     result = parse_node.get_bytes_value()
     assert isinstance(result, bytes)
+    assert result.decode("utf-8") == "U2Ftd2VsIGlzIHRoZSBiZXN0"
 
 
 def test_get_bytes_json_compatible():


### PR DESCRIPTION
serialize objects to bytes in a JSON compatible way

## Overview

Before, if an API returned an object which had been deserilised, and a library serialised it to bytes afterwards, that byte string would not be valid json as python's `str` serialises dictionaries with single quotes.

## Related Issue

https://github.com/microsoftgraph/msgraph-sdk-python-core/issues/807

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output