### PR TITLE
fix: grab the first value if the server response contains a comma

### DIFF
--- a/packages/http/httpx/kiota_http/middleware/retry_handler.py
+++ b/packages/http/httpx/kiota_http/middleware/retry_handler.py
@@ -202,6 +202,7 @@ class RetryHandler(BaseMiddleware):
         Helper to parse Retry-After and get value in seconds.
         """
         try:
+            retry_after = retry_after.split(",")[0] if "," in retry_after else retry_after
             delay = int(retry_after)
         except ValueError:
             # Not an integer? Try HTTP date


### PR DESCRIPTION
## Overview

After encountering a 429 Too Many Requests Error, the server returns an incorrect Retry-After header of "30,120", resulting in an exception in the retry handler. As suggested by @musale in the comments, the function is now splitting the string by the comma and returning the first value.

## Related Issue
Contributes to fix: https://github.com/microsoftgraph/msgraph-sdk-python/issues/1159