### PR TITLE
fix: use asyncio.sleep for non-blocking delay in RetryHandler

### DIFF
--- a/packages/http/httpx/kiota_http/middleware/retry_handler.py
+++ b/packages/http/httpx/kiota_http/middleware/retry_handler.py
@@ -1,7 +1,7 @@
+import asyncio
 import datetime
 import random
 import re
-import time
 from email.utils import parsedate_to_datetime
 
 from kiota_abstractions.request_option import RequestOption
@@ -95,7 +95,7 @@ class RetryHandler(BaseMiddleware):
             # and status code
             should_retry = self.should_retry(request, current_options, response)
             if all([should_retry, retry_valid, delay < RetryHandlerOption.MAX_DELAY]):
-                time.sleep(delay)
+                await asyncio.sleep(delay)
                 # increment the count for retries
                 retry_count += 1
                 request.headers.update({RETRY_ATTEMPT: f'{retry_count}'})


### PR DESCRIPTION
## Overview

The RetryHandler previously used `time.sleep(delay)` to pause between retries. However, `time.sleep` is a blocking call and can halt the entire async event loop, which negatively impacts asynchronous applications like FastAPI.

This PR replaces `time.sleep(delay)` with `await asyncio.sleep(delay)`, ensuring that the sleep is non-blocking and the event loop remains responsive during retry delays. This change improves compatibility and performance in asynchronous environments.

## Related Issue

N.A

### Demo

N.A

### Notes

N.A

## Testing Instructions

All existing Tests pass
