### PR TITLE
fix: ensures BaseMiddleware creates a new span instead of returning the current span

### DIFF
--- a/packages/http/httpx/tests/conftest.py
+++ b/packages/http/httpx/tests/conftest.py
@@ -212,6 +212,11 @@ tracer = trace.get_tracer(__name__)
 
 
 @pytest.fixture
+def otel_tracer():
+    return tracer
+
+
+@pytest.fixture
 def mock_otel_span():
     return tracer.start_span("mock")
 

--- a/packages/http/httpx/tests/middleware_tests/test_base_middleware.py
+++ b/packages/http/httpx/tests/middleware_tests/test_base_middleware.py
@@ -10,9 +10,21 @@ def test_next_is_none():
     assert middleware.next is None
 
 
-def test_span_created(request_info):
-    """Ensures the current span is returned and the parent_span is not set."""
+def test_span_returned(request_info):
+    """Ensures a span is returned and the parent_span is not set."""
     middleware = BaseMiddleware()
-    span = middleware._create_observability_span(request_info, "test_span_created")
+    span = middleware._create_observability_span(request_info, "test_span_returned")
+    span.end()
     assert isinstance(span, trace.Span)
     assert middleware.parent_span is None
+
+
+def test_span_created(request_info, otel_tracer):
+    """Ensures the span returned does not end an outer context managed span"""
+    with otel_tracer.start_as_current_span("outside-span") as outside_span:
+        before_state = outside_span.is_recording()
+        middleware = BaseMiddleware()
+        span = middleware._create_observability_span(request_info, "test_span_created")
+        span.end()
+        after_state = outside_span.is_recording()
+        assert(before_state == after_state)


### PR DESCRIPTION
## Overview

Previously, the _create_observability_span method in the BaseMiddleware would return the current span if no parent_span was given in the request options. Since everything that uses this method treats the returned value as a newly created span, this led to unintentionally modifying and/or ending outside spans that are not directly a part of the middleware/kiota.

I updated this method to, in the event no parent_span is given in the request, create a new span with the middleware's parent_span context or with the current context if needed. This ensures the returned span was created by the method no matter the context.

I also added another test for BaseMiddleware that ensures BaseMiddleware does not end outer spans.

## Related Issue

N/A

## Testing Instructions

* New and modified tests pass
* Other test results identical to main branch