### PR TITLE
fix(json): only convert unambiguous date/datetime/UUID strings in additional data

### DIFF
--- a/packages/serialization/json/kiota_serialization_json/json_parse_node.py
+++ b/packages/serialization/json/kiota_serialization_json/json_parse_node.py
@@ -358,9 +358,17 @@ class JsonParseNode(ParseNode):
                     deserialize but the model doesn't support additional data"
                 )
 
-    def __is_four_digit_number(self, value: str) -> bool:
-        pattern = r'^\d{4}$'
-        return bool(re.match(pattern, value))
+    # Anchored shapes that are unambiguous date/datetime/UUID literals. Untyped
+    # strings are only converted when they match one of these; anything else is
+    # returned as-is. Lenient guessing (time, timedelta, compact/partial dates)
+    # mangled real-world text values such as "19-2026" (parsed as a time with a
+    # UTC offset), "PT" (empty duration) or "11.0" (11:00). This mirrors the
+    # .NET JsonParseNode, which only attempts strict DateTime/DateTimeOffset/
+    # Guid parses on strings.
+    _ISO_DATETIME_OR_DATE_PATTERN = re.compile(r'^\d{4}-\d{2}-\d{2}([Tt ]\d{2}:\d{2}|$)')
+    _CANONICAL_UUID_PATTERN = re.compile(
+        r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+    )
 
     def try_get_anything(self, value: Any) -> Any:
         if isinstance(value, (int, float, bool)) or value is None:
@@ -370,31 +378,16 @@ class JsonParseNode(ParseNode):
         if isinstance(value, dict):
             return dict(map(lambda x: (x[0], self.try_get_anything(x[1])), value.items()))
         if isinstance(value, str):
-            try:
-                if self.__is_four_digit_number(value):
-                    return value
-                if value.isdigit():
-                    return value
-                datetime_obj = datetime_from_iso_format_compat(value)
-                return datetime_obj
-            except ValueError:
-                pass
-            try:
-                return UUID(value)
-            except:
-                pass
-            try:
-                return parse_timedelta_string(value)
-            except ValueError:
-                pass
-            try:
-                return date.fromisoformat(value)
-            except ValueError:
-                pass
-            try:
-                return time_from_iso_format_compat(value)
-            except ValueError:
-                pass
+            if self._ISO_DATETIME_OR_DATE_PATTERN.match(value):
+                try:
+                    return datetime_from_iso_format_compat(value)
+                except ValueError:
+                    pass
+            elif self._CANONICAL_UUID_PATTERN.match(value):
+                try:
+                    return UUID(value)
+                except ValueError:
+                    pass
             return value
         raise ValueError(f"Unexpected additional value type {type(value)} during deserialization.")
 

--- a/packages/serialization/json/tests/unit/test_json_parse_node.py
+++ b/packages/serialization/json/tests/unit/test_json_parse_node.py
@@ -228,6 +228,47 @@ def test_get_anythin_does_convert_date_string_to_datetime():
     assert result == datetime(2023, 10, 5, 14, 48, tzinfo=timezone.utc)
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        # microsoftgraph/msgraph-sdk-python#1340: text values coerced to
+        # datetime.time via lenient time.fromisoformat (3.11+ accepts an
+        # hour plus a UTC-offset-looking suffix or a fraction separator)
+        "19-2026",  # invoice number, parsed as time(19, 0) at offset -20:26
+        "100-012863299",  # invoice number
+        "23.085",  # parsed as time(23, 0, 0, 85000)
+        "11.0",  # version string, parsed as time(11, 0)
+        # coerced to timedelta via parse_timedelta_string
+        "PT",  # country code, parsed as an empty ISO 8601 duration
+        "10:30",  # parsed as hh:mm
+        # microsoft/kiota-python#487: 32-hex string coerced to UUID
+        "d41d8cd98f00b204e9800998ecf8427e",
+        # date-like fragments must not be parsed as dates
+        "12-25",
+        "2023-10",
+    ],
+)
+def test_get_anything_does_not_coerce_text_values(value):
+    parse_node = JsonParseNode(value)
+    result = parse_node.try_get_anything(value)
+    assert isinstance(result, str)
+    assert result == value
+
+
+def test_get_anything_converts_date_only_string_to_datetime():
+    parse_node = JsonParseNode("2023-10-05")
+    result = parse_node.try_get_anything("2023-10-05")
+    assert isinstance(result, datetime)
+    assert result == datetime(2023, 10, 5, 0, 0)
+
+
+def test_get_anything_converts_canonical_uuid_string():
+    parse_node = JsonParseNode("8f841f30-e6e3-439a-a812-ebd369559c36")
+    result = parse_node.try_get_anything("8f841f30-e6e3-439a-a812-ebd369559c36")
+    assert isinstance(result, UUID)
+    assert result == UUID("8f841f30-e6e3-439a-a812-ebd369559c36")
+
+
 def test_get_object_value(user1_json):
     parse_node = JsonParseNode(json.loads(user1_json))
     result = parse_node.get_object_value(User)

--- a/packages/serialization/json/tests/unit/test_json_parse_node.py
+++ b/packages/serialization/json/tests/unit/test_json_parse_node.py
@@ -262,6 +262,40 @@ def test_get_anything_converts_date_only_string_to_datetime():
     assert result == datetime(2023, 10, 5, 0, 0)
 
 
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # date + time, no offset
+        ("2023-10-05T14:48:00", datetime(2023, 10, 5, 14, 48)),
+        ("2023-10-05T14:48:00.123456", datetime(2023, 10, 5, 14, 48, 0, 123456)),
+        # date + time + UTC offset
+        ("2023-10-05T14:48:00Z", datetime(2023, 10, 5, 14, 48, tzinfo=timezone.utc)),
+        ("2023-10-05T14:48:00+00:00", datetime(2023, 10, 5, 14, 48, tzinfo=timezone.utc)),
+        # date + time + non-UTC offset
+        (
+            "2023-10-05T14:48:00+02:00",
+            datetime(2023, 10, 5, 14, 48, tzinfo=timezone(timedelta(hours=2))),
+        ),
+        (
+            "2023-10-05T14:48:00.123456-05:00",
+            datetime(2023, 10, 5, 14, 48, 0, 123456, tzinfo=timezone(timedelta(hours=-5))),
+        ),
+        # lowercase t separator
+        ("2023-10-05t14:48:00Z", datetime(2023, 10, 5, 14, 48, tzinfo=timezone.utc)),
+        # space separator (RFC 3339 permits it for readability)
+        (
+            "2023-10-05 14:48:00+02:00",
+            datetime(2023, 10, 5, 14, 48, tzinfo=timezone(timedelta(hours=2))),
+        ),
+    ],
+)
+def test_get_anything_converts_datetime_with_time_and_offset_variations(value, expected):
+    parse_node = JsonParseNode(value)
+    result = parse_node.try_get_anything(value)
+    assert isinstance(result, datetime)
+    assert result == expected
+
+
 def test_get_anything_converts_canonical_uuid_string():
     parse_node = JsonParseNode("8f841f30-e6e3-439a-a812-ebd369559c36")
     result = parse_node.try_get_anything("8f841f30-e6e3-439a-a812-ebd369559c36")


### PR DESCRIPTION
## Overview

`JsonParseNode.try_get_anything` runs every untyped string (everything landing in `additional_data`) through five lenient parsers in sequence: `datetime_from_iso_format_compat`, `UUID`, `parse_timedelta_string`, `date.fromisoformat`, `time_from_iso_format_compat`. On Python 3.11+ the lenient parsers accept many ordinary text values:

```
'19-2026'       -> datetime.time(19, 0, tzinfo=timezone(timedelta(days=-1, seconds=12840)))  # invoice number
'100-012863299' -> datetime.time(10, 0, ...)                                                 # invoice number
'PT'            -> datetime.timedelta(0)                                                     # country code
'10:30'         -> datetime.timedelta(seconds=37800)
'11.0'          -> datetime.time(11, 0)                                                      # version string
'd41d8cd98f00b204e9800998ecf8427e' -> UUID(...)                                              # 32-hex string
```

This is not just a display problem: in our production SharePoint AP-invoicing app, invoice numbers like `19-2026` were coerced to `time` objects, later stringified on update, and persisted back — permanently corrupting stored data (details with a captured wire payload in microsoftgraph/msgraph-sdk-python#1340).

This PR replaces the speculative parsing with two anchored patterns, mirroring the .NET [`JsonParseNode.TryGetAnything`](https://github.com/microsoft/kiota-dotnet/blob/main/src/serialization/json/JsonParseNode.cs#L510), which only attempts strict `DateTime`/`DateTimeOffset`/`Guid` parses and otherwise returns the string:

- full ISO date or datetime (`^\d{4}-\d{2}-\d{2}([Tt ]\d{2}:\d{2}|$)`) → `datetime_from_iso_format_compat`
- canonical hyphenated UUID → `UUID`

Behavior is unchanged for real payload values: full ISO datetimes still become `datetime`, date-only strings still become `datetime` (same as today, via the same compat parser), canonical UUIDs still become `UUID`. The `timedelta`/`time` guessing is removed entirely — Graph does not send bare durations or times as untyped strings, and their grammars overlap with too much real-world text. The `__is_four_digit_number`/`isdigit()` special cases (added for earlier symptom reports like microsoftgraph/msgraph-sdk-python#653) become unnecessary since all-digit strings cannot match either anchored pattern, and are removed.

## Related Issue

Fixes #487
Addresses microsoftgraph/msgraph-sdk-python#1340 and microsoftgraph/msgraph-sdk-python#653

## Notes

- Strings that previously coerced to `timedelta`/`time`/unhyphenated-UUID will now stay strings in `additional_data`. That is the intent of the fix, but callers who relied on those accidental conversions would see a change; typed model fields are unaffected (they go through declared field deserializers and never reach `try_get_anything`).
- Verified against a live Microsoft Graph SharePoint tenant: text columns round-trip unchanged, `Created`/`Modified` datetimes still parse.

## Testing Instructions

* `cd packages/serialization/json && pytest tests/`
* New parametrized test `test_get_anything_does_not_coerce_text_values` covers each reported corruption pattern (`19-2026`, `PT`, `10:30`, `23.085`, `11.0`, 32-hex, date fragments)
* New tests pin the preserved conversions: date-only → `datetime`, canonical UUID → `UUID`; existing tests cover full ISO datetimes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Uui4g7E7UmzKRGHMW5zbH
