### PR TITLE
Fix/multipart stray linebreak

### DIFF
--- a/packages/abstractions/kiota_abstractions/multipart_body.py
+++ b/packages/abstractions/kiota_abstractions/multipart_body.py
@@ -122,7 +122,7 @@ class MultipartBody(Parsable, Generic[T]):
             if isinstance(part_value[1], Parsable):
                 self._write_parsable(writer, part_value)
             elif isinstance(part_value[1], str):
-                writer.write_str_value("", part_value[1])
+                writer.write_bytes_value("", part_value[1].encode('utf-8'))
             elif isinstance(part_value[1], bytes):
                 writer.write_bytes_value("", part_value[1])
             elif isinstance(part_value[1], io.IOBase):

--- a/packages/serialization/multipart/tests/unit/test_multipart_serialization_writer.py
+++ b/packages/serialization/multipart/tests/unit/test_multipart_serialization_writer.py
@@ -89,3 +89,28 @@ def test_write_object_value_with_filename(user_1, mock_request_adapter, mock_ser
     content = serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == f'--{mock_multipart_body.boundary}'+'\r\nContent-Type: application/json\r\nContent-Disposition: form-data; name="test user"\r\n\r\n{"id": "eac79bd3-fd08-4abf-9df2-2565cf3a3845", "workDuration": "2:00:00", "birthDay": "2017-09-04", "startWorkTime": "00:00:00", "createdDateTime": "2022-01-27T12:59:45", "businessPhones": ["+1 412 555 0109"], "mobilePhone": null, "accountEnabled": false, "jobTitle": "Auditor", "manager": {"id": "eac79bd3-fd08-4abf-9df2-2565cf3a3845"}}\r\n'+f'--{mock_multipart_body.boundary}'+'\r\nContent-Type: application/octet-stream\r\nContent-Disposition: form-data; name="file"; filename="file.txt"\r\n\r\nHello world\r\n'+f'--{mock_multipart_body.boundary}--\r\n'
+
+def test_write_object_value_with_string_part(mock_request_adapter, mock_serialization_writer_factory, mock_multipart_body):
+   mock_request_adapter.get_serialization_writer_factory = Mock(return_value=mock_serialization_writer_factory)
+   mock_multipart_body.request_adapter = mock_request_adapter
+   mock_multipart_body.add_or_replace_part("message", "text/plain", "Hello world")
+
+
+   serialization_writer = MultipartSerializationWriter()
+   serialization_writer.write_object_value("", mock_multipart_body, None)
+   content = serialization_writer.get_serialized_content()
+   content_string = content.decode('utf-8')
+   assert content_string == f'--{mock_multipart_body.boundary}'+'\r\nContent-Type: text/plain\r\nContent-Disposition: form-data; name="message"\r\n\r\nHello world\r\n'+f'--{mock_multipart_body.boundary}--\r\n'
+
+def test_write_object_value_with_multiple_string_parts(mock_request_adapter, mock_serialization_writer_factory, mock_multipart_body):
+   mock_request_adapter.get_serialization_writer_factory = Mock(return_value=mock_serialization_writer_factory)
+   mock_multipart_body.request_adapter = mock_request_adapter
+   mock_multipart_body.add_or_replace_part("message1", "text/plain", "Hello world")
+   mock_multipart_body.add_or_replace_part("message2", "text/plain", "Goodbye world")
+
+
+   serialization_writer = MultipartSerializationWriter()
+   serialization_writer.write_object_value("", mock_multipart_body, None)
+   content = serialization_writer.get_serialized_content()
+   content_string = content.decode('utf-8')
+   assert content_string == f'--{mock_multipart_body.boundary}'+'\r\nContent-Type: text/plain\r\nContent-Disposition: form-data; name="message1"\r\n\r\nHello world\r\n'+f'--{mock_multipart_body.boundary}'+'\r\nContent-Type: text/plain\r\nContent-Disposition: form-data; name="message2"\r\n\r\nGoodbye world\r\n'+f'--{mock_multipart_body.boundary}--\r\n'


### PR DESCRIPTION
## Overview

`MultipartBody.serialize()` writes every string part's value with `write_str_value()`,
which always appends a trailing newline. That newline therefore becomes part of the value
Itself. E.g.  A part meant to hold the value `"helloworld"` is sent as `"helloworld\r\n"`.
Consumers that compare that value exactly would then reject it.

Fixed by writing string part values with `write_bytes_value()` instead, which writes raw bytes with no terminator.

## Related Issue

Fixes #687

### Demo

Before (current `main`), a `text/plain` part with value `"Hello world"`:
```
--boundary\r\nContent-Type: text/plain\r\nContent-Disposition: form-data; name="message"\r\n\r\nHello world\r\n\r\n--boundary--\r\n
```

After (this PR):
```
--boundary\r\nContent-Type: text/plain\r\nContent-Disposition: form-data; name="message"\r\n\r\nHello world\r\n--boundary--\r\n
```

### Notes

- Only string part values are affected. `bytes`/file parts already go through
  `write_bytes_value()` and never carried the stray CRLF.
- No existing test covered a plain `str` part before this PR, every
  `test_write_object_value*` case used a JSON (`Parsable`) part and a `bytes` part, never
  a bare string one.

## Testing Instructions

* `cd packages/serialization/multipart && poetry install`
* `poetry run pytest`
** Expect `test_write_object_value_with_string_part` and
  `test_write_object_value_with_multiple_string_parts` to pass (both fail on `main`
  without this fix (double CRLF before the boundary instead of one))
