### PR TITLE
Add wildcard host matching to AllowedHostsValidator

### DIFF
--- a/packages/abstractions/kiota_abstractions/authentication/allowed_hosts_validator.py
+++ b/packages/abstractions/kiota_abstractions/authentication/allowed_hosts_validator.py
@@ -67,4 +67,11 @@ class AllowedHostsValidator:
             return False
         if not o.hostname:
             return False
-        return o.hostname.lower() in self.allowed_hosts
+        hostname = o.hostname.lower()
+        # Existing exact match
+        if hostname in self.allowed_hosts:
+            return True
+        # Suffix match for entries starting with "."
+        return any(
+            suffix.startswith(".") and hostname.endswith(suffix) for suffix in self.allowed_hosts
+        )

--- a/packages/abstractions/tests/authentication/test_allowed_hosts_validator.py
+++ b/packages/abstractions/tests/authentication/test_allowed_hosts_validator.py
@@ -62,11 +62,28 @@ class TestIsUrlHostValid:
         validator = AllowedHostsValidator(["example.com"])
         assert validator.is_url_host_valid("https://sub.example.com/path") is False
 
+    def test_returns_true_for_subdomain_matching_allowed_suffix(self):
+        validator = AllowedHostsValidator([".fabric.microsoft.com"])
+        assert validator.is_url_host_valid(
+            "https://abc.123.graphql.fabric.microsoft.com/path"
+        ) is True
+
+    def test_returns_false_for_bare_domain_when_allowed_as_suffix(self):
+        validator = AllowedHostsValidator([".fabric.microsoft.com"])
+        assert validator.is_url_host_valid("https://fabric.microsoft.com/path") is False
+
+    def test_suffix_host_matching_is_case_insensitive(self):
+        validator = AllowedHostsValidator([".Fabric.Microsoft.COM"])
+        assert validator.is_url_host_valid("https://ABC.z2c.graphql.fabric.microsoft.com/path") is True
+
     def test_allows_multiple_valid_hosts(self):
-        validator = AllowedHostsValidator(["example.com", "api.example.com"])
+        validator = AllowedHostsValidator(["example.com", "api.example.com", ".fabric.microsoft.com"])
         assert validator.is_url_host_valid("https://example.com/path") is True
         assert validator.is_url_host_valid("https://api.example.com/path") is True
         assert validator.is_url_host_valid("https://other.com/path") is False
+        assert validator.is_url_host_valid(
+            "https://abc.123.graphql.fabric.microsoft.com/path"
+        ) is True
 
     def test_handles_url_with_port(self):
         validator = AllowedHostsValidator(["example.com"])
@@ -93,3 +110,10 @@ class TestSetAllowedHosts:
         validator = AllowedHostsValidator(["example.com"])
         with pytest.raises(ValueError):
             validator.set_allowed_hosts(["http://example.com"])
+
+    def test_allows_suffix_based_hosts_after_update(self):
+        validator = AllowedHostsValidator(["example.com"])
+        validator.set_allowed_hosts([".fabric.microsoft.com"])
+        assert validator.is_url_host_valid(
+            "https://abc.123.graphql.fabric.microsoft.com/path"
+        ) is True


### PR DESCRIPTION
Support wildcard patterns in the allowlist so trusted host groups can be managed without listing every subdomain explicitly. Keep strict host normalization and validation to preserve safe trust decisions.

## Overview

This PR extends `AllowedHostsValidator` to support wildcard-style host matching via suffix entries (for example, `.fabric.microsoft.com`) while preserving exact-match behavior.

This is needed for APIs that use dynamic or tenant-specific subdomains, where enumerating every hostname is not practical. With this change, callers can keep host validation enabled instead of falling back to an empty allowed_hosts list.

## Related Issue

Fixes [#700](https://github.com/microsoft/kiota-python/issues/700)

### Demo

```python
validator = AllowedHostsValidator([".fabric.microsoft.com"])

validator.is_url_host_valid("https://2c662c47.z2c.graphql.fabric.microsoft.com")  # True
validator.is_url_host_valid("https://fabric.microsoft.com")                         # False
```

### Notes

Suffix entries are intentionally subdomain-only:
- `.fabric.microsoft.com` matches `foo.fabric.microsoft.com`
- `.fabric.microsoft.com` does **not** match `fabric.microsoft.com`

Exact host entries continue to work as before.

## Testing Instructions

* Check out this branch
* From repo root, run:
  * `pwsh -File .\kiota-python.ps1 test`
* Or run package-scoped tests:
  * `Set-Location .\packages\abstractions`
  * `poetry install`
  * `poetry run pytest .\tests\authentication\test_allowed_hosts_validator.py`
* Verify expected behavior:
  * wildcard/suffix entries match dynamic subdomains
  * bare domain is rejected for suffix entries
  * matching is case-insensitive
  * `set_allowed_hosts(...)` keeps suffix behavior
