### PR TITLE
fix(serialization-json): serialize nested arrays recursively

### DIFF
--- a/packages/serialization/json/kiota_serialization_json/json_serialization_writer.py
+++ b/packages/serialization/json/kiota_serialization_json/json_serialization_writer.py
@@ -487,8 +487,13 @@ class JsonSerializationWriter(SerializationWriter):
                 self.write_collection_of_primitive_values(key, value)
             elif all(isinstance(x, dict) for x in value):
                 self.__write_collection_of_dict_values(key, value)
-            else:
+            elif all(isinstance(x, list) for x in value):
                 self.write_collection_of_primitive_values(key, value)
+            else:
+                raise TypeError(
+                    f"Encountered an unknown collection type during serialization {type(value)}\
+                    with key {key}"
+                )
         elif isinstance(value, dict):
             self.__write_dict_value(key, value)
         else:

--- a/packages/serialization/json/kiota_serialization_json/json_serialization_writer.py
+++ b/packages/serialization/json/kiota_serialization_json/json_serialization_writer.py
@@ -488,10 +488,7 @@ class JsonSerializationWriter(SerializationWriter):
             elif all(isinstance(x, dict) for x in value):
                 self.__write_collection_of_dict_values(key, value)
             else:
-                raise TypeError(
-                    f"Encountered an unknown collection type during serialization {type(value)}\
-                    with key {key}"
-                )
+                self.write_collection_of_primitive_values(key, value)
         elif isinstance(value, dict):
             self.__write_dict_value(key, value)
         else:

--- a/packages/serialization/json/tests/unit/test_json_serialization_writer.py
+++ b/packages/serialization/json/tests/unit/test_json_serialization_writer.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date, datetime
 from uuid import UUID
 
@@ -206,6 +207,40 @@ def test_write_collection_of_primitive_values():
     content = json_serialization_writer.get_serialized_content()
     content_string = content.decode('utf-8')
     assert content_string == '{"businessPhones": ["+1 412 555 0109", 1]}'
+
+
+@pytest.mark.parametrize("key", [None, "matrix"])
+@pytest.mark.parametrize("value", [
+    [[1, 2, 3]],
+    [[], [[1], [2, 3]]],
+    [1, [2, None], {"nested": [[], [3]]}, False],
+])
+def test_write_any_value_nested_lists(key, value):
+    writer = JsonSerializationWriter()
+    writer.write_any_value(key, value)
+    expected = {key: value} if key else value
+    assert json.loads(writer.get_serialized_content()) == expected
+
+
+def test_write_additional_data_nested_lists():
+    writer = JsonSerializationWriter()
+    value = {"matrix": [[1, 2], [3, 4]]}
+    writer.write_additional_data_value(value)
+    assert json.loads(writer.get_serialized_content()) == value
+
+
+def test_write_any_value_nested_lists_serializes_models(user_2):
+    writer = JsonSerializationWriter()
+    writer.write_any_value(None, [[user_2, date(2022, 1, 27)]])
+    assert json.loads(writer.get_serialized_content()) == [
+        [{"display_name": "John Doe", "age": 32}, "2022-01-27"]
+    ]
+
+
+def test_write_any_value_nested_lists_rejects_unsupported_values():
+    writer = JsonSerializationWriter()
+    with pytest.raises(TypeError):
+        writer.write_any_value(None, [[object()]])
 
 
 def test_write_collection_of_object_values(user_1, user_2):

--- a/packages/serialization/json/tests/unit/test_json_serialization_writer.py
+++ b/packages/serialization/json/tests/unit/test_json_serialization_writer.py
@@ -213,7 +213,7 @@ def test_write_collection_of_primitive_values():
 @pytest.mark.parametrize("value", [
     [[1, 2, 3]],
     [[], [[1], [2, 3]]],
-    [1, [2, None], {"nested": [[], [3]]}, False],
+    [[1, None], [False], [{"nested": [[], [3]]}]],
 ])
 def test_write_any_value_nested_lists(key, value):
     writer = JsonSerializationWriter()
@@ -231,9 +231,9 @@ def test_write_additional_data_nested_lists():
 
 def test_write_any_value_nested_lists_serializes_models(user_2):
     writer = JsonSerializationWriter()
-    writer.write_any_value(None, [[user_2, date(2022, 1, 27)]])
+    writer.write_any_value(None, [[user_2], [date(2022, 1, 27)]])
     assert json.loads(writer.get_serialized_content()) == [
-        [{"display_name": "John Doe", "age": 32}, "2022-01-27"]
+        [{"display_name": "John Doe", "age": 32}], ["2022-01-27"]
     ]
 
 
@@ -241,6 +241,13 @@ def test_write_any_value_nested_lists_rejects_unsupported_values():
     writer = JsonSerializationWriter()
     with pytest.raises(TypeError):
         writer.write_any_value(None, [[object()]])
+
+
+@pytest.mark.parametrize("value", [[1, [2]], [{"value": 1}, [2]], [[1], None]])
+def test_write_any_value_rejects_mixed_collection_types(value):
+    writer = JsonSerializationWriter()
+    with pytest.raises(TypeError, match="Encountered an unknown collection type"):
+        writer.write_any_value(None, value)
 
 
 def test_write_collection_of_object_values(user_1, user_2):


### PR DESCRIPTION
`write_any_value("matrix", [[1, 2, 3]])` raises `TypeError` because the list dispatcher has no branch for nested lists.

Add an explicit `all(isinstance(x, list) for x in value)` branch, consistent with the neighboring dictionary check, and delegate to the existing recursive element writer. Keep the existing unknown-collection exception and specialized collection paths. This supports nested lists without accepting previously unsupported mixtures of lists and scalar/model/dictionary values at the same level.

Validation (Python 3.12):
- Regression coverage includes root/property values, additional data, empty arrays, dictionaries, model objects, and dates within nested lists.
- Three rejection cases failed before the review update and pass after it, confirming mixed collections retain the existing `TypeError`.
- JSON package: `pytest -q` — 120 passed.
- YAPF, isort, mypy, and `git diff --check` passed.
- Pylint rated the package 10/10 and reports the existing unrecognized `suggestion-mode` configuration option.

Closes #478.

Prepared with AI assistance; reproduction and validation ran locally.
