### PR TITLE
fix(serialization-form): omit the root object assignment prefix

### DIFF
--- a/packages/serialization/form/kiota_serialization_form/form_serialization_writer.py
+++ b/packages/serialization/form/kiota_serialization_form/form_serialization_writer.py
@@ -207,7 +207,9 @@ class FormSerializationWriter(SerializationWriter):
 
         if len(self.writer) > 0:
             self.writer += "&"
-        self.writer += f"{quote_plus(key.strip()) if key is not None else ''}={temp_writer.writer}"
+        if key:
+            self.writer += f"{quote_plus(key.strip())}="
+        self.writer += temp_writer.writer
         self.depth -= 1
 
     def write_null_value(self, key: Optional[str]) -> None:

--- a/packages/serialization/form/kiota_serialization_form/form_serialization_writer.py
+++ b/packages/serialization/form/kiota_serialization_form/form_serialization_writer.py
@@ -205,11 +205,12 @@ class FormSerializationWriter(SerializationWriter):
         if value and self._on_after_object_serialization:
             self._on_after_object_serialization(value)
 
-        if len(self.writer) > 0:
-            self.writer += "&"
-        if key:
-            self.writer += f"{quote_plus(key.strip())}="
-        self.writer += temp_writer.writer
+        if key or temp_writer.writer:
+            if len(self.writer) > 0:
+                self.writer += "&"
+            if key:
+                self.writer += f"{quote_plus(key.strip())}="
+            self.writer += temp_writer.writer
         self.depth -= 1
 
     def write_null_value(self, key: Optional[str]) -> None:

--- a/packages/serialization/form/tests/unit/test_form_serialization_writer.py
+++ b/packages/serialization/form/tests/unit/test_form_serialization_writer.py
@@ -190,3 +190,32 @@ def test_write_object_value(user_1):
         "floatValue=3.14"
     )
 
+
+@pytest.mark.parametrize("key", [None, ""])
+def test_write_root_object_value(key):
+    entity = TestEntity(additional_data={"body": "example", "title": "a&b"})
+    writer = FormSerializationWriter()
+    writer.write_object_value(key, entity)
+    assert writer.get_serialized_content() == b"body=example&title=a%26b"
+
+
+def test_write_root_object_after_existing_field():
+    entity = TestEntity(additional_data={"body": "example"})
+    writer = FormSerializationWriter()
+    writer.write_str_value("first", "value")
+    writer.write_object_value(None, entity)
+    assert writer.get_serialized_content() == b"first=value&body=example"
+
+
+def test_write_root_object_with_additional_values():
+    entity = TestEntity(additional_data={"body": "example"})
+    additional = TestEntity(additional_data={"title": "example title"})
+    writer = FormSerializationWriter()
+    writer.write_object_value(None, entity, additional)
+    assert writer.get_serialized_content() == b"body=example&title=example+title"
+
+
+def test_write_empty_root_object():
+    writer = FormSerializationWriter()
+    writer.write_object_value(None, TestEntity())
+    assert writer.get_serialized_content() == b""

--- a/packages/serialization/form/tests/unit/test_form_serialization_writer.py
+++ b/packages/serialization/form/tests/unit/test_form_serialization_writer.py
@@ -219,3 +219,20 @@ def test_write_empty_root_object():
     writer = FormSerializationWriter()
     writer.write_object_value(None, TestEntity())
     assert writer.get_serialized_content() == b""
+
+
+@pytest.mark.parametrize("key", [None, ""])
+def test_write_empty_root_object_between_fields(key):
+    writer = FormSerializationWriter()
+    writer.write_str_value("first", "value")
+    writer.write_object_value(key, TestEntity())
+    assert writer.get_serialized_content() == b"first=value"
+    writer.write_object_value(None, TestEntity(additional_data={"last": "value"}))
+    assert writer.get_serialized_content() == b"first=value&last=value"
+
+
+def test_write_empty_named_object_after_existing_field():
+    writer = FormSerializationWriter()
+    writer.write_str_value("first", "value")
+    writer.write_object_value("empty", TestEntity())
+    assert writer.get_serialized_content() == b"first=value&empty="


### PR DESCRIPTION
Serializing a root form object with `write_object_value(None, model)` produces `=body=example` instead of `body=example`. The writer omits the absent key but still emits its assignment separator.

Only add the key and `=` when a key is supplied. Root objects now contribute their encoded fields directly. Empty roots leave existing output untouched; named empty objects still emit their key and assignment separator. Named-object serialization and field escaping retain their existing behavior.

Validation (Python 3.12):
- Five regressions failed before the change: absent/empty root keys, an existing field, merged object values, and an empty root object.
- Review regression: empty roots after an existing field failed for both absent and empty-string keys before the follow-up fix. Added a named-empty-object compatibility check.
- Form package: `pytest -q` — 53 passed.
- YAPF, isort, mypy, and `git diff --check` passed.
- Pylint exited successfully with 10/10; it also reports the existing unrecognized `suggestion-mode` configuration option.

Closes #476.

Prepared with AI assistance; reproduction and validation ran locally.
