### PR TITLE
fix(authentication-azure): preserve caller-owned async credentials

### DIFF
--- a/packages/authentication/azure/README.md
+++ b/packages/authentication/azure/README.md
@@ -17,6 +17,12 @@ In order to use this library, install the package by running:
 pip install microsoft-kiota-authentication-azure
 ```
 
+The application owns the credential passed to `AzureIdentityAccessTokenProvider`.
+The provider leaves it open so it can be reused for token refreshes, concurrent
+requests, or multiple clients. Close the credential after all clients using it
+have finished. For async Azure Identity credentials, use an `async with` context
+manager around the client lifetime or call `await credential.close()` at shutdown.
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/packages/authentication/azure/kiota_authentication_azure/azure_identity_access_token_provider.py
+++ b/packages/authentication/azure/kiota_authentication_azure/azure_identity_access_token_provider.py
@@ -20,6 +20,8 @@ class AzureIdentityAccessTokenProvider(AccessTokenProvider):
     """
     Access token provider that leverages the Azure Identity library to retrieve
     an access token.
+
+    The caller owns the credential and must close it when it is no longer needed.
     """
 
     IS_VALID_URL = "com.microsoft.kiota.authentication.is_url_valid"
@@ -112,7 +114,6 @@ class AzureIdentityAccessTokenProvider(AccessTokenProvider):
 
             if inspect.isawaitable(result):
                 result = await result
-                await self._credentials.close()  # type: ignore
 
             if result and isinstance(result, AccessToken):
                 return result.token

--- a/packages/authentication/azure/tests/test_azure_identity_access_token_provider.py
+++ b/packages/authentication/azure/tests/test_azure_identity_access_token_provider.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from kiota_abstractions.authentication import AllowedHostsValidator
 
@@ -52,6 +54,51 @@ async def test_get_authorization_token_async():
     token_provider = AzureIdentityAccessTokenProvider(DummyAsyncAzureTokenCredential(), None)
     token = await token_provider.get_authorization_token('https://graph.microsoft.com')
     assert token == "This is a dummy token"
+
+
+class ReusableAsyncCredential(DummyAsyncAzureTokenCredential):
+    def __init__(self):
+        self.closed = False
+
+    async def get_token(self, *args, **kwargs):
+        await asyncio.sleep(0)
+        if self.closed:
+            raise RuntimeError("Credential transport is closed")
+        return await super().get_token(*args, **kwargs)
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("shared", [False, True])
+async def test_async_credential_remains_reusable(shared):
+    credential = ReusableAsyncCredential()
+    provider = AzureIdentityAccessTokenProvider(credential, None)
+    next_provider = AzureIdentityAccessTokenProvider(credential, None) if shared else provider
+    try:
+        first = await provider.get_authorization_token('https://graph.microsoft.com')
+        second = await next_provider.get_authorization_token('https://graph.microsoft.com')
+        assert first == second == "This is a dummy token"
+        assert not credential.closed
+    finally:
+        await credential.close()
+    assert credential.closed
+
+
+@pytest.mark.asyncio
+async def test_async_credential_supports_concurrent_requests():
+    credential = ReusableAsyncCredential()
+    provider = AzureIdentityAccessTokenProvider(credential, None)
+    try:
+        tokens = await asyncio.gather(*[
+            provider.get_authorization_token('https://graph.microsoft.com')
+            for _ in range(3)
+        ])
+        assert tokens == ["This is a dummy token"] * 3
+        assert not credential.closed
+    finally:
+        await credential.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`AzureIdentityAccessTokenProvider` closes an async credential immediately after retrieving a token. Reusing that credential for a later request, sharing it across providers, or acquiring tokens concurrently can then fail because its transport is already closed.

Leave the caller-owned credential open after token acquisition, matching the synchronous path. Document that the application must close it after all clients have finished, using its async context manager or `await credential.close()`.

Validation (Python 3.12):
- Three regressions failed on the original code: sequential requests, two providers sharing one credential, and concurrent requests. Tests use a credential double with an observable closed state and exercise the real provider; no live Azure credentials or network calls are needed.
- Authentication Azure package: `pytest -q` — 21 passed.
- YAPF, isort, mypy, wheel build, and `git diff --check` passed.
- Pylint exited successfully with 10/10; it also reports the existing unrecognized `suggestion-mode` configuration option.

Closes #528. Related lifetime discussion: #365.

Prepared with AI assistance; reproduction and validation ran locally.
