### PR TITLE
fix(http): close the wrapped async transport

### DIFF
--- a/packages/http/httpx/kiota_http/middleware/async_kiota_transport.py
+++ b/packages/http/httpx/kiota_http/middleware/async_kiota_transport.py
@@ -18,3 +18,7 @@ class AsyncKiotaTransport(httpx.AsyncBaseTransport):
 
         response = await self.transport.handle_async_request(request)
         return response
+
+    async def aclose(self) -> None:
+        """Close the wrapped transport."""
+        await self.transport.aclose()

--- a/packages/http/httpx/tests/test_kiota_client_factory.py
+++ b/packages/http/httpx/tests/test_kiota_client_factory.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import httpx
 import pytest
 
@@ -157,3 +159,81 @@ def test_create_middleware_pipeline():
     )
 
     assert isinstance(pipeline, MiddlewarePipeline)
+
+
+class ClosingTransport(httpx.MockTransport):
+
+    def __init__(self, handler):
+        super().__init__(handler)
+        self.close_count = 0
+
+    async def aclose(self):
+        self.close_count += 1
+        await super().aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('use_context_manager', [False, True])
+async def test_client_closes_wrapped_transports(use_context_manager):
+    transport = ClosingTransport(lambda request: httpx.Response(200))
+    mounted_transport = ClosingTransport(lambda request: httpx.Response(200))
+    client = KiotaClientFactory.create_with_default_middleware(
+        httpx.AsyncClient(
+            transport=transport,
+            mounts={'https://mounted.example.com': mounted_transport},
+            trust_env=False
+        )
+    )
+
+    async def send_requests():
+        assert (await client.get('https://example.com')).status_code == 200
+        assert (await client.get('https://mounted.example.com')).status_code == 200
+        assert transport.close_count == 0
+        assert mounted_transport.close_count == 0
+
+    if use_context_manager:
+        async with client:
+            await send_requests()
+    else:
+        await send_requests()
+        await client.aclose()
+
+    assert client.is_closed
+    assert transport.close_count == 1
+    assert mounted_transport.close_count == 1
+    await client.aclose()
+    assert transport.close_count == 1
+    assert mounted_transport.close_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('error_type', [RuntimeError, asyncio.CancelledError])
+async def test_client_closes_wrapped_transport_after_request_failure(error_type):
+    def fail_request(request):
+        raise error_type('request interrupted')
+
+    transport = ClosingTransport(fail_request)
+    client = KiotaClientFactory.create_with_default_middleware(
+        httpx.AsyncClient(transport=transport, trust_env=False)
+    )
+
+    with pytest.raises(error_type, match='request interrupted'):
+        async with client:
+            await client.get('https://example.com')
+
+    assert client.is_closed
+    assert transport.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_client_propagates_wrapped_transport_close_failure(mocker):
+    transport = httpx.MockTransport(lambda request: httpx.Response(200))
+    close = mocker.patch.object(transport, 'aclose', side_effect=RuntimeError('close failed'))
+    client = KiotaClientFactory.create_with_default_middleware(
+        httpx.AsyncClient(transport=transport, trust_env=False)
+    )
+
+    with pytest.raises(RuntimeError, match='close failed'):
+        await client.aclose()
+
+    close.assert_awaited_once()


### PR DESCRIPTION
Closing a client created by `KiotaClientFactory` currently leaves its underlying transport open. `AsyncKiotaTransport` inherits the no-op `AsyncBaseTransport.aclose()`, so both explicit client closure and async context exit stop at the wrapper.

Delegate `aclose()` to the wrapped transport. This restores the HTTPX client lifecycle contract without changing request processing or credential ownership. Cleanup exceptions propagate to the caller.

Validation on Python 3.13.14:

- Five regression cases failed on upstream before the fix. They cover explicit closure, context exit, mounted transports, request exceptions, cancellation, repeated client closure, and cleanup errors using the real HTTPX client and Kiota factory.
- `pytest -q tests/test_kiota_client_factory.py`: 15 passed.
- `pytest -q`: 115 passed; upstream baseline was 110 passed.
- `yapf -dr kiota_http`, `mypy kiota_http`, and `git diff --check`: passed. Mypy checked 24 source files.
- `pylint kiota_http --disable=W --rcfile=.pylintrc`: exit 0, 10/10, with the existing unrecognized `suggestion-mode` option diagnostic.
- CI's `isort kiota_http`: exit 0. A supplementary `--check-only` run identifies one existing blank-line issue in untouched `redirect_handler_option.py`, also reproduced from the upstream file. No unrelated formatting change is included; the changed implementation passes the import check.
- `uv build --wheel --out-dir <external-artifacts-directory>`: passed.

Tests use in-memory transports and no live credentials or external HTTP service. Other Python versions and platforms were not run locally.

Closes #494.

Prepared with AI assistance; reproduction and validation ran locally.
